### PR TITLE
Update go.mod to target Go 1.22

### DIFF
--- a/chessTest/go.mod
+++ b/chessTest/go.mod
@@ -1,3 +1,3 @@
 module battle_chess_poc
 
-go 1.25.1
+go 1.22


### PR DESCRIPTION
## Summary
- set the module go directive to the supported Go 1.22 toolchain
- refreshed module metadata with `go mod tidy` using Go 1.22
- rebuilt the server to confirm it compiles under Go 1.22

## Testing
- GOTOOLCHAIN=go1.22.6 go mod tidy
- GOTOOLCHAIN=go1.22.6 go build ./cmd/server

------
https://chatgpt.com/codex/tasks/task_e_68d9c6c1fdd8832385cdf1a44b1b0087