### PR TITLE
Handle slider movement cost initialization safely

### DIFF
--- a/chessTest/internal/game/moves.go
+++ b/chessTest/internal/game/moves.go
@@ -348,14 +348,20 @@ func (e *Engine) calculateMovementCost(pc *Piece, from, to Square) int {
 	cost := 1 // Basic movement costs 1 step.
 
 	// Sliders (Queen, Rook, Bishop) pay an extra step to change direction mid-turn.
-	if e.isSlider(pc.Type) && len(e.currentMove.Path) > 1 {
-		prevFrom := e.currentMove.Path[len(e.currentMove.Path)-2]
-		prevDir := shared.DirectionOf(prevFrom, from)
-		currentDir := shared.DirectionOf(from, to)
+	if e.isSlider(pc.Type) {
+		pathLen := 0
+		if e.currentMove != nil {
+			pathLen = len(e.currentMove.Path)
+		}
+		if pathLen > 1 {
+			prevFrom := e.currentMove.Path[pathLen-2]
+			prevDir := shared.DirectionOf(prevFrom, from)
+			currentDir := shared.DirectionOf(from, to)
 
-		if prevDir != currentDir && prevDir != DirNone && currentDir != DirNone {
-			cost++ // Direction change costs an extra step.
-			appendAbilityNote(&e.board.lastNote, "Direction change cost +1 step")
+			if prevDir != currentDir && prevDir != DirNone && currentDir != DirNone {
+				cost++ // Direction change costs an extra step.
+				appendAbilityNote(&e.board.lastNote, "Direction change cost +1 step")
+			}
 		}
 	}
 	return cost

--- a/chessTest/internal/game/moves_test.go
+++ b/chessTest/internal/game/moves_test.go
@@ -1,0 +1,75 @@
+package game
+
+import "testing"
+
+func TestSliderOpeningMovesDoNotPanic(t *testing.T) {
+	tests := []struct {
+		name     string
+		from     string
+		to       string
+		removals []string
+	}{
+		{
+			name:     "Rook",
+			from:     "a1",
+			to:       "a3",
+			removals: []string{"a2"},
+		},
+		{
+			name:     "Bishop",
+			from:     "c1",
+			to:       "g5",
+			removals: []string{"d2"},
+		},
+		{
+			name:     "Queen",
+			from:     "d1",
+			to:       "h5",
+			removals: []string{"d2", "e2"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			eng := NewEngine()
+			if err := eng.SetSideConfig(White, AbilityList{AbilityDoOver}, ElementLight); err != nil {
+				t.Fatalf("configure white: %v", err)
+			}
+			if err := eng.SetSideConfig(Black, AbilityList{AbilityDoOver}, ElementShadow); err != nil {
+				t.Fatalf("configure black: %v", err)
+			}
+
+			for _, coord := range tt.removals {
+				sq, ok := CoordToSquare(coord)
+				if !ok {
+					t.Fatalf("invalid removal coordinate %q", coord)
+				}
+				pc := eng.board.pieceAt[sq]
+				if pc == nil {
+					t.Fatalf("no piece to remove at %s", coord)
+				}
+				eng.removePiece(pc, sq)
+			}
+
+			fromSq, ok := CoordToSquare(tt.from)
+			if !ok {
+				t.Fatalf("invalid from square %q", tt.from)
+			}
+			toSq, ok := CoordToSquare(tt.to)
+			if !ok {
+				t.Fatalf("invalid to square %q", tt.to)
+			}
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("move panicked: %v", r)
+				}
+			}()
+
+			if err := eng.Move(MoveRequest{From: fromSq, To: toSq, Dir: DirNone}); err != nil {
+				t.Fatalf("move returned error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- guard slider direction-change cost calculation when no move state exists yet
- add a regression test that exercises opening rook, bishop, and queen moves without panicking

## Testing
- go test ./internal/game

------
https://chatgpt.com/codex/tasks/task_e_68d9c762e2188323b87bd67e6b3a4abf