### PR TITLE
Update BlockPath direction select values

### DIFF
--- a/chessTest/web/static/app.js
+++ b/chessTest/web/static/app.js
@@ -73,9 +73,9 @@
     const ph = document.createElement("option");
     ph.value = ""; ph.textContent = "Auto / Not needed";
     dirSelect.appendChild(ph);
-    DIRS.forEach((d, i) => {
+    DIRS.forEach((d) => {
       const opt = document.createElement("option");
-      opt.value = String(i);
+      opt.value = d;
       opt.textContent = d;
       dirSelect.appendChild(opt);
     });


### PR DESCRIPTION
## Summary
- update the BlockPath direction dropdown to submit compass labels instead of numeric indices so the backend parser accepts the chosen facing

## Testing
- `curl -s -X POST http://localhost:8080/api/move -H 'Content-Type: application/json' -d '{"from":"e2","to":"e4","dir":"N"}'`


------
https://chatgpt.com/codex/tasks/task_e_68d9caa4b21483239a8649dec922c0ea