### PR TITLE
Expose engine lock state

### DIFF
--- a/chessTest/internal/game/state.go
+++ b/chessTest/internal/game/state.go
@@ -145,6 +145,7 @@ type BoardState struct {
 	Abilities   map[string][]string `json:"abilities"`
 	Elements    map[string]string   `json:"elements"`
 	BlockFacing map[int]Direction   `json:"blockFacing"`
+	Locked      bool                `json:"locked"`
 }
 
 // ---------------------------
@@ -276,6 +277,7 @@ func (e *Engine) State() BoardState {
 		Abilities:   make(map[string][]string),
 		Elements:    make(map[string]string),
 		BlockFacing: make(map[int]Direction),
+		Locked:      e.locked,
 	}
 
 	for _, pc := range e.board.pieceAt {

--- a/chessTest/web/static/app.js
+++ b/chessTest/web/static/app.js
@@ -4,7 +4,7 @@
   // ===== Bootstrap & shared state =====
   const initScript = document.getElementById("__init");
   const init = initScript ? JSON.parse(initScript.textContent || "{}") : {};
-  let state = init.state || {
+  const defaultState = {
     pieces: [],        // [{id, type, color, square, element?}]
     blockFacing: {},   // { [pieceId]: directionIndex }
     abilities: {},
@@ -14,6 +14,8 @@
     lastNote: "",
     locked: false
   };
+  let state = Object.assign({}, defaultState, init.state || {});
+  state.locked = !!state.locked;
   let selectedSquare = null;   // 0..63
   let possibleMoves = [];      // UI hint only
   let isAnimating = false;
@@ -353,7 +355,8 @@
   // ===== State/UI =====
   function updateState(res) {
     const st = res && (res.state || res) || {};
-    state = st;
+    state = Object.assign({}, state || defaultState, st);
+    state.locked = !!state.locked;
     renderBoard();
     updateConfigUI();
     updateMoveUI();


### PR DESCRIPTION
## Summary
- add the engine's lock status to the serialized BoardState so API clients can see when configuration is closed
- ensure the web app carries the locked flag across state updates to toggle configuration and move controls accordingly

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d9cb93c95483238acffdfc57f83cc4