### PR TITLE
Add castling, en passant, and promotion support

### DIFF
--- a/chessTest/internal/game/types.go
+++ b/chessTest/internal/game/types.go
@@ -10,7 +10,11 @@ type (
 	Square    = shared.Square
 	Direction = shared.Direction
 
-	AbilityList = shared.AbilityList
+	AbilityList      = shared.AbilityList
+	CastlingRights   = shared.CastlingRights
+	CastlingSide     = shared.CastlingSide
+	EnPassantTarget  = shared.EnPassantTarget
+	PromotionChoices = shared.PromotionChoices
 )
 
 const (
@@ -70,11 +74,29 @@ const (
 	DirW    = shared.DirW
 	DirNW   = shared.DirNW
 	DirNone = shared.DirNone
+
+	CastlingNone = shared.CastlingNone
+	CastlingAll  = shared.CastlingAll
+
+	PromotionNone = shared.PromotionNone
+	PromotionAll  = shared.PromotionAll
+
+	CastleKingside  = shared.CastleKingside
+	CastleQueenside = shared.CastleQueenside
 )
 
 var (
-	AllAbilities = shared.AllAbilities
-	AllElements  = shared.AllElements
+	AllAbilities              = shared.AllAbilities
+	AllElements               = shared.AllElements
+	ParseCastlingRights       = shared.ParseCastlingRights
+	CastlingRight             = shared.CastlingRight
+	CastlingRightsForColor    = shared.CastlingRightsForColor
+	NewEnPassantTarget        = shared.NewEnPassantTarget
+	NoEnPassantTarget         = shared.NoEnPassantTarget
+	ParseEnPassantTarget      = shared.ParseEnPassantTarget
+	PromotionChoicesFromTypes = shared.PromotionChoicesFromTypes
+	ParsePromotionPiece       = shared.ParsePromotionPiece
+	ParsePromotionChoices     = shared.ParsePromotionChoices
 )
 
 type SideConfig = struct {

--- a/chessTest/internal/shared/types.go
+++ b/chessTest/internal/shared/types.go
@@ -1,6 +1,9 @@
 package shared
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type Color uint8
 
@@ -208,4 +211,344 @@ func CoordToSquare(coord string) (Square, bool) {
 	r := int(rank - '1')
 	c := int(file - 'a')
 	return Square(r*8 + c), true
+}
+
+// ---------------------------
+// Castling Rights
+// ---------------------------
+
+type CastlingRights uint8
+
+const (
+	CastlingNone          CastlingRights = 0
+	CastlingWhiteKingside CastlingRights = 1 << iota
+	CastlingWhiteQueenside
+	CastlingBlackKingside
+	CastlingBlackQueenside
+	CastlingAll = CastlingWhiteKingside | CastlingWhiteQueenside | CastlingBlackKingside | CastlingBlackQueenside
+)
+
+type CastlingSide uint8
+
+const (
+	CastleKingside CastlingSide = iota
+	CastleQueenside
+)
+
+func (cs CastlingSide) String() string {
+	switch cs {
+	case CastleKingside:
+		return "kingside"
+	case CastleQueenside:
+		return "queenside"
+	default:
+		return "?"
+	}
+}
+
+func CastlingRight(color Color, side CastlingSide) CastlingRights {
+	switch color {
+	case White:
+		if side == CastleQueenside {
+			return CastlingWhiteQueenside
+		}
+		return CastlingWhiteKingside
+	case Black:
+		if side == CastleQueenside {
+			return CastlingBlackQueenside
+		}
+		return CastlingBlackKingside
+	default:
+		return CastlingNone
+	}
+}
+
+func CastlingRightsForColor(color Color) CastlingRights {
+	switch color {
+	case White:
+		return CastlingWhiteKingside | CastlingWhiteQueenside
+	case Black:
+		return CastlingBlackKingside | CastlingBlackQueenside
+	default:
+		return CastlingNone
+	}
+}
+
+func (cr CastlingRights) Has(right CastlingRights) bool { return cr&right != 0 }
+
+func (cr CastlingRights) HasSide(color Color, side CastlingSide) bool {
+	return cr.Has(CastlingRight(color, side))
+}
+
+func (cr CastlingRights) With(right CastlingRights) CastlingRights { return cr | right }
+
+func (cr CastlingRights) Without(right CastlingRights) CastlingRights { return cr &^ right }
+
+func (cr CastlingRights) WithoutColor(color Color) CastlingRights {
+	return cr.Without(CastlingRightsForColor(color))
+}
+
+func (cr CastlingRights) String() string {
+	if cr == CastlingNone {
+		return "-"
+	}
+	var b strings.Builder
+	if cr.Has(CastlingWhiteKingside) {
+		b.WriteByte('K')
+	}
+	if cr.Has(CastlingWhiteQueenside) {
+		b.WriteByte('Q')
+	}
+	if cr.Has(CastlingBlackKingside) {
+		b.WriteByte('k')
+	}
+	if cr.Has(CastlingBlackQueenside) {
+		b.WriteByte('q')
+	}
+	if b.Len() == 0 {
+		return "-"
+	}
+	return b.String()
+}
+
+func ParseCastlingRights(s string) (CastlingRights, error) {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" || trimmed == "-" {
+		return CastlingNone, nil
+	}
+	var rights CastlingRights
+	for _, r := range trimmed {
+		switch r {
+		case 'K':
+			rights |= CastlingWhiteKingside
+		case 'Q':
+			rights |= CastlingWhiteQueenside
+		case 'k':
+			rights |= CastlingBlackKingside
+		case 'q':
+			rights |= CastlingBlackQueenside
+		default:
+			return CastlingNone, fmt.Errorf("invalid castling flag %q", string(r))
+		}
+	}
+	return rights, nil
+}
+
+func (cr CastlingRights) MarshalText() ([]byte, error) { return []byte(cr.String()), nil }
+
+func (cr *CastlingRights) UnmarshalText(text []byte) error {
+	parsed, err := ParseCastlingRights(string(text))
+	if err != nil {
+		return err
+	}
+	*cr = parsed
+	return nil
+}
+
+// ---------------------------
+// En-passant targets
+// ---------------------------
+
+type EnPassantTarget struct {
+	square Square
+	valid  bool
+}
+
+func NewEnPassantTarget(sq Square) EnPassantTarget { return EnPassantTarget{square: sq, valid: true} }
+
+func NoEnPassantTarget() EnPassantTarget { return EnPassantTarget{} }
+
+func (e EnPassantTarget) Valid() bool { return e.valid }
+
+func (e EnPassantTarget) Square() (Square, bool) {
+	if !e.valid {
+		return 0, false
+	}
+	return e.square, true
+}
+
+func (e EnPassantTarget) String() string {
+	if !e.valid {
+		return "-"
+	}
+	return e.square.String()
+}
+
+func ParseEnPassantTarget(s string) (EnPassantTarget, error) {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" || trimmed == "-" {
+		return EnPassantTarget{}, nil
+	}
+	sq, ok := CoordToSquare(strings.ToLower(trimmed))
+	if !ok {
+		return EnPassantTarget{}, fmt.Errorf("invalid en-passant square %q", s)
+	}
+	return NewEnPassantTarget(sq), nil
+}
+
+func (e EnPassantTarget) MarshalText() ([]byte, error) { return []byte(e.String()), nil }
+
+func (e *EnPassantTarget) UnmarshalText(text []byte) error {
+	parsed, err := ParseEnPassantTarget(string(text))
+	if err != nil {
+		return err
+	}
+	*e = parsed
+	return nil
+}
+
+// ---------------------------
+// Promotion choices
+// ---------------------------
+
+type PromotionChoices uint8
+
+const (
+	PromotionNone  PromotionChoices = 0
+	PromoteToQueen PromotionChoices = 1 << iota
+	PromoteToRook
+	PromoteToBishop
+	PromoteToKnight
+	PromotionAll = PromoteToQueen | PromoteToRook | PromoteToBishop | PromoteToKnight
+)
+
+func PromotionChoicesFromTypes(types ...PieceType) PromotionChoices {
+	var choices PromotionChoices
+	for _, pt := range types {
+		choices = choices.WithPiece(pt)
+	}
+	return choices
+}
+
+func (pc PromotionChoices) WithPiece(pt PieceType) PromotionChoices {
+	switch pt {
+	case Queen:
+		return pc | PromoteToQueen
+	case Rook:
+		return pc | PromoteToRook
+	case Bishop:
+		return pc | PromoteToBishop
+	case Knight:
+		return pc | PromoteToKnight
+	default:
+		return pc
+	}
+}
+
+func (pc PromotionChoices) WithoutPiece(pt PieceType) PromotionChoices {
+	switch pt {
+	case Queen:
+		return pc &^ PromoteToQueen
+	case Rook:
+		return pc &^ PromoteToRook
+	case Bishop:
+		return pc &^ PromoteToBishop
+	case Knight:
+		return pc &^ PromoteToKnight
+	default:
+		return pc
+	}
+}
+
+func (pc PromotionChoices) Contains(pt PieceType) bool {
+	switch pt {
+	case Queen:
+		return pc&PromoteToQueen != 0
+	case Rook:
+		return pc&PromoteToRook != 0
+	case Bishop:
+		return pc&PromoteToBishop != 0
+	case Knight:
+		return pc&PromoteToKnight != 0
+	default:
+		return false
+	}
+}
+
+func (pc PromotionChoices) Types() []PieceType {
+	var out []PieceType
+	for _, pt := range []PieceType{Queen, Rook, Bishop, Knight} {
+		if pc.Contains(pt) {
+			out = append(out, pt)
+		}
+	}
+	return out
+}
+
+func (pc PromotionChoices) Default() PieceType {
+	for _, pt := range []PieceType{Queen, Rook, Bishop, Knight} {
+		if pc.Contains(pt) {
+			return pt
+		}
+	}
+	return Queen
+}
+
+func (pc PromotionChoices) String() string {
+	if pc == PromotionNone {
+		return "-"
+	}
+	var b strings.Builder
+	if pc.Contains(Queen) {
+		b.WriteByte('Q')
+	}
+	if pc.Contains(Rook) {
+		b.WriteByte('R')
+	}
+	if pc.Contains(Bishop) {
+		b.WriteByte('B')
+	}
+	if pc.Contains(Knight) {
+		b.WriteByte('N')
+	}
+	if b.Len() == 0 {
+		return "-"
+	}
+	return b.String()
+}
+
+func ParsePromotionPiece(s string) (PieceType, bool) {
+	trimmed := strings.TrimSpace(strings.ToLower(s))
+	switch trimmed {
+	case "q", "queen":
+		return Queen, true
+	case "r", "rook":
+		return Rook, true
+	case "b", "bishop":
+		return Bishop, true
+	case "n", "knight":
+		return Knight, true
+	default:
+		return 0, false
+	}
+}
+
+func ParsePromotionChoices(s string) (PromotionChoices, error) {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" || trimmed == "-" {
+		return PromotionNone, nil
+	}
+	var choices PromotionChoices
+	for _, r := range trimmed {
+		if r == ',' || r == ' ' || r == '/' {
+			continue
+		}
+		pt, ok := ParsePromotionPiece(string(r))
+		if !ok {
+			return PromotionNone, fmt.Errorf("invalid promotion piece %q", string(r))
+		}
+		choices = choices.WithPiece(pt)
+	}
+	return choices, nil
+}
+
+func (pc PromotionChoices) MarshalText() ([]byte, error) { return []byte(pc.String()), nil }
+
+func (pc *PromotionChoices) UnmarshalText(text []byte) error {
+	parsed, err := ParsePromotionChoices(string(text))
+	if err != nil {
+		return err
+	}
+	*pc = parsed
+	return nil
 }


### PR DESCRIPTION
## Summary
- add shared types for castling rights, en-passant targets, and promotion choices along with parsing helpers
- track castling, en-passant, and promotion metadata in the engine and update move execution to handle those rules
- generate castle/en-passant/promotion moves, expose promotion selection over HTTP, and cover the new flows with tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68da9b3bddb483239ca02ce56b5482e3