### PR TITLE
Use color-indexed arrays for engine state

### DIFF
--- a/chessTest/internal/game/ability_resolver.go
+++ b/chessTest/internal/game/ability_resolver.go
@@ -86,7 +86,7 @@ func (e *Engine) trySmartExtraCapture(attacker *Piece, captureSquare Square, vic
 		if !e.canAbilityRemove(attacker, p) {
 			continue
 		}
-		if elementOf(e, p) == ElementEarth || p.Abilities.Contains(AbilityObstinant) || e.abilities[p.Color].Contains(AbilityObstinant) {
+		if elementOf(e, p) == ElementEarth || p.Abilities.Contains(AbilityObstinant) || e.abilities[p.Color.Index()].Contains(AbilityObstinant) {
 			continue
 		}
 		r := rankOf(p.Type)

--- a/chessTest/internal/game/history.go
+++ b/chessTest/internal/game/history.go
@@ -6,10 +6,10 @@ type undoState struct {
 	blockFacing   map[int]Direction
 	lastNote      string
 	locked        bool
-	configured    map[Color]bool
+	configured    [2]bool
 	pendingDoOver map[int]bool
 	currentMove   *MoveState
-	temporalSlow  map[Color]int
+	temporalSlow  [2]int
 }
 
 func cloneMoveState(src *MoveState, pieceMap map[*Piece]*Piece) *MoveState {
@@ -47,33 +47,11 @@ func cloneIntDirectionMap(src map[int]Direction) map[int]Direction {
 	return clone
 }
 
-func cloneColorBoolMap(src map[Color]bool) map[Color]bool {
-	if len(src) == 0 {
-		return make(map[Color]bool)
-	}
-	clone := make(map[Color]bool, len(src))
-	for k, v := range src {
-		clone[k] = v
-	}
-	return clone
-}
-
 func cloneIntBoolMap(src map[int]bool) map[int]bool {
 	if len(src) == 0 {
 		return make(map[int]bool)
 	}
 	clone := make(map[int]bool, len(src))
-	for k, v := range src {
-		clone[k] = v
-	}
-	return clone
-}
-
-func cloneColorIntMap(src map[Color]int) map[Color]int {
-	if len(src) == 0 {
-		return make(map[Color]int)
-	}
-	clone := make(map[Color]int, len(src))
 	for k, v := range src {
 		clone[k] = v
 	}
@@ -91,10 +69,10 @@ func (e *Engine) snapshot() undoState {
 		blockFacing:   cloneIntDirectionMap(e.blockFacing),
 		lastNote:      e.board.lastNote,
 		locked:        e.locked,
-		configured:    cloneColorBoolMap(e.configured),
+		configured:    e.configured,
 		pendingDoOver: cloneIntBoolMap(e.pendingDoOver),
 		currentMove:   moveCopy,
-		temporalSlow:  cloneColorIntMap(e.temporalSlow),
+		temporalSlow:  e.temporalSlow,
 	}
 	return s
 }
@@ -105,9 +83,9 @@ func (e *Engine) applySnapshot(s undoState) {
 	e.blockFacing = cloneIntDirectionMap(s.blockFacing)
 	e.board.lastNote = s.lastNote
 	e.locked = s.locked
-	e.configured = cloneColorBoolMap(s.configured)
+	e.configured = s.configured
 	e.pendingDoOver = cloneIntBoolMap(s.pendingDoOver)
-	e.temporalSlow = cloneColorIntMap(s.temporalSlow)
+	e.temporalSlow = s.temporalSlow
 	if s.currentMove != nil {
 		e.currentMove = cloneMoveState(s.currentMove, mapping)
 	} else {

--- a/chessTest/internal/game/moves.go
+++ b/chessTest/internal/game/moves.go
@@ -503,17 +503,13 @@ func (e *Engine) applyTemporalLockSlow(pc *Piece) {
 	if pc == nil || !pc.Abilities.Contains(AbilityTemporalLock) {
 		return
 	}
-	if e.temporalSlow == nil {
-		e.temporalSlow = make(map[Color]int, 2)
-	}
-
 	slow := 1
 	if elementOf(e, pc) == ElementFire {
 		slow = 2
 	}
 
 	opponent := pc.Color.Opposite()
-	e.temporalSlow[opponent] = slow
+	e.temporalSlow[opponent.Index()] = slow
 	appendAbilityNote(&e.board.lastNote, fmt.Sprintf("Temporal Lock slows %s by %d", opponent, slow))
 }
 
@@ -555,12 +551,9 @@ func (e *Engine) calculateStepBudget(pc *Piece) int {
 			bonus++ // Interaction bonus with Side Step
 		}
 	}
-	slowPenalty := 0
-	if e.temporalSlow != nil {
-		if slow, ok := e.temporalSlow[pc.Color]; ok {
-			slowPenalty = slow
-			delete(e.temporalSlow, pc.Color)
-		}
+	slowPenalty := e.temporalSlow[pc.Color.Index()]
+	if slowPenalty > 0 {
+		e.temporalSlow[pc.Color.Index()] = 0
 	}
 
 	totalSteps := baseSteps + bonus - slowPenalty

--- a/chessTest/internal/game/moves_test.go
+++ b/chessTest/internal/game/moves_test.go
@@ -919,7 +919,7 @@ func TestResurrectionCaptureWindowExpires(t *testing.T) {
 	if steps := eng.calculateStepBudget(eng.board.pieceAt[start]); steps < 3 {
 		t.Fatalf("expected at least 3 steps with buffs, got %d", steps)
 	}
-	if eng.abilities[Black].Contains(AbilityDoOver) {
+	if eng.abilities[Black.Index()].Contains(AbilityDoOver) {
 		t.Fatalf("black side unexpectedly configured with Do-Over")
 	}
 	if pc := eng.board.pieceAt[firstCapture]; pc == nil {

--- a/chessTest/internal/game/piece_ops.go
+++ b/chessTest/internal/game/piece_ops.go
@@ -67,8 +67,8 @@ func (e *Engine) placePiece(color Color, pt PieceType, sq Square) {
 		Color:     color,
 		Type:      pt,
 		Square:    sq,
-		Abilities: e.abilities[color].Clone(),
-		Element:   e.elements[color],
+		Abilities: e.abilities[color.Index()].Clone(),
+		Element:   e.elements[color.Index()],
 		BlockDir:  DirNone,
 	}
 	e.board.pieceAt[sq] = pc
@@ -189,17 +189,15 @@ func (e *Engine) canPhaseThrough(pc *Piece, _ Square, _ Square) bool {
 	hasBastion := pc.Abilities.Contains(AbilityBastion)
 	hasGale := pc.Abilities.Contains(AbilityGaleLift)
 
-	if e.abilities != nil {
-		if al, ok := e.abilities[pc.Color]; ok {
-			if al.Contains(AbilityFloodWake) {
-				hasFlood = true
-			}
-			if al.Contains(AbilityBastion) {
-				hasBastion = true
-			}
-			if al.Contains(AbilityGaleLift) {
-				hasGale = true
-			}
+	if al := e.abilities[pc.Color.Index()]; len(al) > 0 {
+		if al.Contains(AbilityFloodWake) {
+			hasFlood = true
+		}
+		if al.Contains(AbilityBastion) {
+			hasBastion = true
+		}
+		if al.Contains(AbilityGaleLift) {
+			hasGale = true
 		}
 	}
 
@@ -212,10 +210,8 @@ func (e *Engine) canPhaseThrough(pc *Piece, _ Square, _ Square) bool {
 	if pc.Abilities.Contains(AbilityUmbralStep) {
 		return true
 	}
-	if e.abilities != nil {
-		if al, ok := e.abilities[pc.Color]; ok && al.Contains(AbilityUmbralStep) {
-			return true
-		}
+	if al := e.abilities[pc.Color.Index()]; len(al) > 0 && al.Contains(AbilityUmbralStep) {
+		return true
 	}
 	return false
 }

--- a/chessTest/internal/shared/types.go
+++ b/chessTest/internal/shared/types.go
@@ -19,6 +19,8 @@ func (c Color) Opposite() Color {
 	return White
 }
 
+func (c Color) Index() int { return int(c) }
+
 func (c Color) String() string {
 	if c == White {
 		return "white"


### PR DESCRIPTION
## Summary
- replace color-keyed maps in the engine with fixed arrays for abilities, elements, configuration, and temporal slow state
- update history snapshots and related helpers to copy these arrays directly instead of cloning maps
- adjust move logic, ability resolution, and tests to use the new color indexing helper

## Testing
- go test ./internal/game

------
https://chatgpt.com/codex/tasks/task_e_68dab7964c608323b746d2a72f958152