### PR TITLE
Add ability handler registry module

### DIFF
--- a/chessTest/internal/game/abilities/handler.go
+++ b/chessTest/internal/game/abilities/handler.go
@@ -1,0 +1,233 @@
+package abilities
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"battle_chess_poc/internal/game"
+	"battle_chess_poc/internal/shared"
+)
+
+// AbilityHandler represents the lifecycle hooks that an ability can implement
+// to integrate with the engine. Handlers may implement any subset of the
+// methods; unused hooks should return default values.
+type AbilityHandler interface {
+	StepBudgetModifier(ctx StepBudgetContext) (StepBudgetDelta, error)
+	CanPhase(ctx PhaseContext) (bool, error)
+	OnMoveStart(ctx MoveLifecycleContext) error
+	OnSegmentStart(ctx SegmentContext) error
+	OnCapture(ctx CaptureContext) error
+	OnTurnEnd(ctx TurnEndContext) error
+}
+
+// HandlerFactory constructs a new AbilityHandler instance.
+type HandlerFactory func() AbilityHandler
+
+// StepBudgetContext carries the data required to adjust the initial step budget
+// for a move.
+type StepBudgetContext struct {
+	Engine *game.Engine
+	Piece  *game.Piece
+	Move   *game.MoveState // nil before the MoveState is created
+}
+
+// StepBudgetDelta encapsulates modifications to the starting step budget.
+type StepBudgetDelta struct {
+	AddSteps int
+	Notes    []string
+}
+
+// PhaseContext supplies phasing calculations with the origin and destination
+// squares under consideration.
+type PhaseContext struct {
+	Engine *game.Engine
+	Piece  *game.Piece
+	From   shared.Square
+	To     shared.Square
+}
+
+// MoveLifecycleContext provides data for hooks that run when a new move begins.
+type MoveLifecycleContext struct {
+	Engine  *game.Engine
+	Move    *game.MoveState
+	Request game.MoveRequest
+	Segment SegmentMetadata
+}
+
+// SegmentMetadata mirrors the runtime data captured for a move segment.
+type SegmentMetadata struct {
+	Capture       *game.Piece
+	CaptureSquare shared.Square
+	EnPassant     bool
+}
+
+// SegmentContext tracks the state for a particular move segment within a turn.
+type SegmentContext struct {
+	Engine      *game.Engine
+	Move        *game.MoveState
+	From        shared.Square
+	To          shared.Square
+	Segment     SegmentMetadata
+	SegmentStep int // zero-based index within the turn
+}
+
+// CaptureContext mirrors the data supplied when a capture occurs during a
+// segment.
+type CaptureContext struct {
+	Engine        *game.Engine
+	Move          *game.MoveState
+	Attacker      *game.Piece
+	Victim        *game.Piece
+	CaptureSquare shared.Square
+	SegmentStep   int
+}
+
+// TurnEndContext communicates the reason a turn is ending along with the
+// active runtime state.
+type TurnEndContext struct {
+	Engine *game.Engine
+	Move   *game.MoveState
+	Reason TurnEndReason
+}
+
+// TurnEndReason describes why a turn is finishing.
+type TurnEndReason int
+
+const (
+	// TurnEndNatural indicates the player completed their turn normally.
+	TurnEndNatural TurnEndReason = iota
+	// TurnEndForced signals that an effect or rule forced the turn to stop.
+	TurnEndForced
+	// TurnEndCancelled denotes that the turn was aborted due to an error or veto.
+	TurnEndCancelled
+)
+
+// HandlerFuncs provides a convenient adapter that allows handlers to override
+// only the hooks they need. Any nil function pointer results in a neutral
+// response so the registry can safely skip unused hooks.
+type HandlerFuncs struct {
+	StepBudgetModifierFunc func(StepBudgetContext) (StepBudgetDelta, error)
+	CanPhaseFunc           func(PhaseContext) (bool, error)
+	OnMoveStartFunc        func(MoveLifecycleContext) error
+	OnSegmentStartFunc     func(SegmentContext) error
+	OnCaptureFunc          func(CaptureContext) error
+	OnTurnEndFunc          func(TurnEndContext) error
+}
+
+// StepBudgetModifier invokes the configured modifier hook if present.
+func (hf HandlerFuncs) StepBudgetModifier(ctx StepBudgetContext) (StepBudgetDelta, error) {
+	if hf.StepBudgetModifierFunc == nil {
+		return StepBudgetDelta{}, nil
+	}
+	return hf.StepBudgetModifierFunc(ctx)
+}
+
+// CanPhase invokes the configured phasing hook if present.
+func (hf HandlerFuncs) CanPhase(ctx PhaseContext) (bool, error) {
+	if hf.CanPhaseFunc == nil {
+		return false, nil
+	}
+	return hf.CanPhaseFunc(ctx)
+}
+
+// OnMoveStart invokes the configured move-start hook if present.
+func (hf HandlerFuncs) OnMoveStart(ctx MoveLifecycleContext) error {
+	if hf.OnMoveStartFunc == nil {
+		return nil
+	}
+	return hf.OnMoveStartFunc(ctx)
+}
+
+// OnSegmentStart invokes the configured segment-start hook if present.
+func (hf HandlerFuncs) OnSegmentStart(ctx SegmentContext) error {
+	if hf.OnSegmentStartFunc == nil {
+		return nil
+	}
+	return hf.OnSegmentStartFunc(ctx)
+}
+
+// OnCapture invokes the configured capture hook if present.
+func (hf HandlerFuncs) OnCapture(ctx CaptureContext) error {
+	if hf.OnCaptureFunc == nil {
+		return nil
+	}
+	return hf.OnCaptureFunc(ctx)
+}
+
+// OnTurnEnd invokes the configured turn-end hook if present.
+func (hf HandlerFuncs) OnTurnEnd(ctx TurnEndContext) error {
+	if hf.OnTurnEndFunc == nil {
+		return nil
+	}
+	return hf.OnTurnEndFunc(ctx)
+}
+
+var (
+	registryMu sync.RWMutex
+	registry   map[shared.Ability]HandlerFactory
+
+	// ErrDuplicateRegistration indicates an ability already has a handler factory.
+	ErrDuplicateRegistration = errors.New("abilities: handler already registered")
+	// ErrNilFactory indicates a registration attempt provided a nil constructor.
+	ErrNilFactory = errors.New("abilities: nil handler factory")
+	// ErrInvalidAbility indicates the ability identifier is not valid for registration.
+	ErrInvalidAbility = errors.New("abilities: invalid ability identifier")
+	// ErrUnknownAbility indicates no handler factory has been registered for the ability.
+	ErrUnknownAbility = errors.New("abilities: handler not registered")
+	// ErrNilHandler indicates a factory returned a nil handler instance.
+	ErrNilHandler = errors.New("abilities: factory produced nil handler")
+)
+
+// Register associates an ability with a handler factory. The function is safe
+// for concurrent use.
+func Register(id shared.Ability, ctor HandlerFactory) error {
+	if id == shared.AbilityNone {
+		return ErrInvalidAbility
+	}
+	if ctor == nil {
+		return ErrNilFactory
+	}
+
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if registry == nil {
+		registry = make(map[shared.Ability]HandlerFactory)
+	}
+	if _, exists := registry[id]; exists {
+		return fmt.Errorf("%w: %s", ErrDuplicateRegistration, id.String())
+	}
+	registry[id] = ctor
+	return nil
+}
+
+// New creates a handler instance for the requested ability using the registered
+// factory.
+func New(id shared.Ability) (AbilityHandler, error) {
+	registryMu.RLock()
+	ctor := registry[id]
+	registryMu.RUnlock()
+
+	if ctor == nil {
+		return nil, fmt.Errorf("%w: %s", ErrUnknownAbility, id.String())
+	}
+
+	handler := ctor()
+	if handler == nil {
+		return nil, fmt.Errorf("%w: %s", ErrNilHandler, id.String())
+	}
+	return handler, nil
+}
+
+// registeredAbilities returns a copy of the registered ability identifiers. It
+// is primarily intended for debugging and tests.
+func registeredAbilities() []shared.Ability {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	out := make([]shared.Ability, 0, len(registry))
+	for id := range registry {
+		out = append(out, id)
+	}
+	return out
+}

--- a/chessTest/internal/game/abilities/handler_test.go
+++ b/chessTest/internal/game/abilities/handler_test.go
@@ -1,0 +1,123 @@
+package abilities
+
+import (
+	"errors"
+	"testing"
+
+	"battle_chess_poc/internal/game"
+	"battle_chess_poc/internal/shared"
+)
+
+func resetRegistry(t *testing.T) {
+	t.Helper()
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry = make(map[shared.Ability]HandlerFactory)
+}
+
+func TestRegisterAndNew(t *testing.T) {
+	resetRegistry(t)
+
+	handler := HandlerFuncs{
+		OnMoveStartFunc: func(MoveLifecycleContext) error {
+			return nil
+		},
+	}
+
+	if err := Register(shared.AbilityScorch, func() AbilityHandler { return handler }); err != nil {
+		t.Fatalf("register ability: %v", err)
+	}
+
+	instance, err := New(shared.AbilityScorch)
+	if err != nil {
+		t.Fatalf("new handler: %v", err)
+	}
+
+	if _, err := instance.StepBudgetModifier(StepBudgetContext{}); err != nil {
+		t.Fatalf("step budget modifier: %v", err)
+	}
+	if err := instance.OnMoveStart(MoveLifecycleContext{}); err != nil {
+		t.Fatalf("on move start: %v", err)
+	}
+}
+
+func TestRegisterDuplicate(t *testing.T) {
+	resetRegistry(t)
+
+	ctor := func() AbilityHandler { return HandlerFuncs{} }
+	if err := Register(shared.AbilityScorch, ctor); err != nil {
+		t.Fatalf("first registration: %v", err)
+	}
+	if err := Register(shared.AbilityScorch, ctor); !errors.Is(err, ErrDuplicateRegistration) {
+		t.Fatalf("expected ErrDuplicateRegistration, got %v", err)
+	}
+}
+
+func TestRegisterNilFactory(t *testing.T) {
+	resetRegistry(t)
+	if err := Register(shared.AbilityScorch, nil); !errors.Is(err, ErrNilFactory) {
+		t.Fatalf("expected ErrNilFactory, got %v", err)
+	}
+}
+
+func TestRegisterInvalidAbility(t *testing.T) {
+	resetRegistry(t)
+	if err := Register(shared.AbilityNone, func() AbilityHandler { return HandlerFuncs{} }); !errors.Is(err, ErrInvalidAbility) {
+		t.Fatalf("expected ErrInvalidAbility, got %v", err)
+	}
+}
+
+func TestNewMissingAbility(t *testing.T) {
+	resetRegistry(t)
+	if _, err := New(shared.AbilityScorch); !errors.Is(err, ErrUnknownAbility) {
+		t.Fatalf("expected ErrUnknownAbility, got %v", err)
+	}
+}
+
+func TestNewNilHandler(t *testing.T) {
+	resetRegistry(t)
+	if err := Register(shared.AbilityScorch, func() AbilityHandler { return nil }); err != nil {
+		t.Fatalf("register ability: %v", err)
+	}
+	if _, err := New(shared.AbilityScorch); !errors.Is(err, ErrNilHandler) {
+		t.Fatalf("expected ErrNilHandler, got %v", err)
+	}
+}
+
+func TestRegisteredAbilitiesIsCopy(t *testing.T) {
+	resetRegistry(t)
+	if err := Register(shared.AbilityScorch, func() AbilityHandler { return HandlerFuncs{} }); err != nil {
+		t.Fatalf("register ability: %v", err)
+	}
+
+	ids := registeredAbilities()
+	if len(ids) != 1 || ids[0] != shared.AbilityScorch {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+
+	// Mutating the returned slice should not affect the registry.
+	ids[0] = shared.AbilityDoOver
+
+	registryMu.RLock()
+	_, exists := registry[shared.AbilityScorch]
+	_, mutated := registry[shared.AbilityDoOver]
+	registryMu.RUnlock()
+
+	if !exists {
+		t.Fatalf("ability scorch missing after mutation")
+	}
+	if mutated {
+		t.Fatalf("registry mutated after slice modification")
+	}
+}
+
+// Ensure the handler functions compile against the expected runtime types.
+func TestContextTypes(t *testing.T) {
+	t.Helper()
+	_ = StepBudgetContext{Engine: (*game.Engine)(nil), Piece: (*game.Piece)(nil), Move: (*game.MoveState)(nil)}
+	_ = PhaseContext{Engine: (*game.Engine)(nil), Piece: (*game.Piece)(nil)}
+	_ = MoveLifecycleContext{Engine: (*game.Engine)(nil), Move: (*game.MoveState)(nil), Request: game.MoveRequest{}, Segment: SegmentMetadata{}}
+	_ = SegmentContext{Engine: (*game.Engine)(nil), Move: (*game.MoveState)(nil), Segment: SegmentMetadata{}}
+	_ = CaptureContext{Engine: (*game.Engine)(nil), Move: (*game.MoveState)(nil), Attacker: (*game.Piece)(nil), Victim: (*game.Piece)(nil)}
+	_ = TurnEndContext{Engine: (*game.Engine)(nil), Move: (*game.MoveState)(nil), Reason: TurnEndForced}
+}


### PR DESCRIPTION
## Summary
- add an `internal/game/abilities` package with the ability handler interface and lifecycle contexts from the Task 13 design
- implement a thread-safe registry for ability handler factories with helper adapters for optional hooks
- cover registration, lookup, and edge cases with dedicated unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dad5dda8d0832391e8438dfa3b12e6