### PR TITLE
Refactor MoveState to use per-ability runtime map

### DIFF
--- a/chessTest/internal/game/ability_resolver.go
+++ b/chessTest/internal/game/ability_resolver.go
@@ -42,8 +42,8 @@ func (e *Engine) ResolveCaptureAbility(attacker, victim *Piece, captureSquare Sq
 		}
 	}
 
-	if attacker != nil && e.currentMove != nil && e.currentMove.HasQuantumKill && !e.currentMove.QuantumKillUsed {
-		e.currentMove.QuantumKillUsed = true
+	if attacker != nil && e.currentMove != nil && attacker.Abilities.Contains(AbilityQuantumKill) && !e.currentMove.abilityUsed(AbilityQuantumKill) {
+		e.currentMove.markAbilityUsed(AbilityQuantumKill)
 		if target := e.findQuantumKillTarget(attacker, victimColor, victimRank); target != nil {
 			targetSquare := target.Square
 			if removed, err := e.attemptAbilityRemoval(attacker, target); err != nil {

--- a/chessTest/internal/game/engine.go
+++ b/chessTest/internal/game/engine.go
@@ -386,14 +386,6 @@ func (e *Engine) hasChainKill(p *Piece) bool {
 	return p != nil && p.Abilities.Contains(AbilityChainKill)
 }
 
-func (e *Engine) hasQuantumKill(p *Piece) bool {
-	return p != nil && p.Abilities.Contains(AbilityQuantumKill)
-}
-
-func (e *Engine) hasDoubleKill(p *Piece) bool {
-	return p != nil && p.Abilities.Contains(AbilityDoubleKill)
-}
-
 func (e *Engine) isSlider(pt PieceType) bool { return pt == Queen || pt == Rook || pt == Bishop }
 
 var RankOrder = map[PieceType]int{King: 5, Queen: 4, Rook: 3, Bishop: 2, Knight: 2, Pawn: 1}
@@ -684,7 +676,7 @@ func (e *Engine) resurrectionWindowActive(pc *Piece) bool {
 	if e.currentMove == nil || e.currentMove.Piece != pc {
 		return false
 	}
-	return e.currentMove.ResurrectionWindow
+	return e.currentMove.abilityFlag(AbilityResurrection, abilityFlagWindow)
 }
 
 func (e *Engine) addResurrectionCaptureWindow(pc *Piece, moves Bitboard) Bitboard {

--- a/chessTest/internal/game/history.go
+++ b/chessTest/internal/game/history.go
@@ -159,6 +159,14 @@ func cloneMoveState(src *MoveState) *MoveState {
 	clone := *src
 	clone.Path = append([]Square(nil), src.Path...)
 	clone.Captures = append([]*Piece(nil), src.Captures...)
+	if len(src.AbilityData) > 0 {
+		clone.AbilityData = make(map[Ability]*AbilityRuntime, len(src.AbilityData))
+		for ability, runtime := range src.AbilityData {
+			clone.AbilityData[ability] = runtime.Clone()
+		}
+	} else {
+		clone.AbilityData = nil
+	}
 	return &clone
 }
 

--- a/chessTest/internal/game/moves_test.go
+++ b/chessTest/internal/game/moves_test.go
@@ -106,7 +106,7 @@ func TestMistShroudFreePivot(t *testing.T) {
 	if eng.currentMove == nil {
 		t.Fatalf("expected current move to remain active after Mist Shroud pivot")
 	}
-	if got := eng.currentMove.FreeTurnsUsed; got != 1 {
+	if got := eng.currentMove.abilityCounter(AbilityMistShroud, abilityCounterFree); got != 1 {
 		t.Fatalf("expected one free pivot, got %d", got)
 	}
 	if got := eng.currentMove.RemainingSteps; got != 1 {
@@ -654,7 +654,7 @@ func TestQuantumStepBlinkConsumesStepAndBlocksSecondUse(t *testing.T) {
 	if eng.currentMove.RemainingSteps != remainingBefore-1 {
 		t.Fatalf("expected steps to decrease by 1, got %d from %d", eng.currentMove.RemainingSteps, remainingBefore)
 	}
-	if !eng.currentMove.QuantumStepUsed {
+	if !eng.currentMove.abilityUsed(AbilityQuantumStep) {
 		t.Fatalf("expected quantum step flag to be set after blink")
 	}
 
@@ -727,7 +727,7 @@ func TestQuantumStepSwapMovesFriendlyPiece(t *testing.T) {
 	if eng.currentMove.RemainingSteps != remainingBefore-1 {
 		t.Fatalf("expected steps to decrease by 1 after swap, got %d from %d", eng.currentMove.RemainingSteps, remainingBefore)
 	}
-	if !eng.currentMove.QuantumStepUsed {
+	if !eng.currentMove.abilityUsed(AbilityQuantumStep) {
 		t.Fatalf("expected quantum step flag to be set after swap")
 	}
 }
@@ -843,7 +843,7 @@ func TestSideStepNudge(t *testing.T) {
 		if got := eng.currentMove.RemainingSteps; got != stepsBefore-1 {
 			t.Fatalf("expected remaining steps to drop from %d to %d, got %d", stepsBefore, stepsBefore-1, got)
 		}
-		if !eng.currentMove.SideStepUsed {
+		if !eng.currentMove.abilityUsed(AbilitySideStep) {
 			t.Fatalf("expected side step usage to latch")
 		}
 		if pc := eng.board.pieceAt[diagonal]; pc == nil || pc.Color != White {


### PR DESCRIPTION
## Summary
- replace MoveState's scattered ability flags with a shared AbilityRuntime map that handlers can own
- clone the per-ability runtime state during history snapshots and update resurrection helpers to read from it
- adjust move logic and tests to use the new ability runtime helpers

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dadb7704c88323ba9e0aab353e5338