### PR TITLE
Refine capture runtime bookkeeping

### DIFF
--- a/chessTest/internal/game/engine.go
+++ b/chessTest/internal/game/engine.go
@@ -382,10 +382,6 @@ func (e *Engine) selectPromotionPiece(color Color) PieceType {
 	return choices.Default()
 }
 
-func (e *Engine) hasChainKill(p *Piece) bool {
-	return p != nil && p.Abilities.Contains(AbilityChainKill)
-}
-
 func (e *Engine) isSlider(pt PieceType) bool { return pt == Queen || pt == Rook || pt == Bishop }
 
 var RankOrder = map[PieceType]int{King: 5, Queen: 4, Rook: 3, Bishop: 2, Knight: 2, Pawn: 1}
@@ -675,6 +671,9 @@ func (e *Engine) resurrectionWindowActive(pc *Piece) bool {
 	}
 	if e.currentMove == nil || e.currentMove.Piece != pc {
 		return false
+	}
+	if e.currentMove.abilityCounter(AbilityResurrection, abilityFlagWindow) > 0 {
+		return true
 	}
 	return e.currentMove.abilityFlag(AbilityResurrection, abilityFlagWindow)
 }

--- a/chessTest/internal/game/piece_ops.go
+++ b/chessTest/internal/game/piece_ops.go
@@ -16,6 +16,14 @@ type moveSegmentContext struct {
 	enPassant     bool
 }
 
+func (ctx moveSegmentContext) metadata() SegmentMetadata {
+	return SegmentMetadata{
+		Capture:       ctx.capture,
+		CaptureSquare: ctx.captureSquare,
+		EnPassant:     ctx.enPassant,
+	}
+}
+
 func (e *Engine) executeMoveSegment(from, to Square, ctx moveSegmentContext) {
 	pc := e.board.pieceAt[from]
 	if pc == nil {


### PR DESCRIPTION
## Summary
- track capture counts, limits, and metadata through MoveState ability runtime counters
- seed and consume the capture counters during move start, capture registration, and resurrection window resets
- expose segment metadata for capture bookkeeping and have resurrection checks read the handler-managed counters

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dade397a4c83238f0c3a63eb1f6576