### PR TITLE
Integrate ability handler lifecycle into engine

### DIFF
--- a/chessTest/cmd/server/main.go
+++ b/chessTest/cmd/server/main.go
@@ -10,7 +10,8 @@ import (
 	"strings"
 
 	// Adjust these imports to your actual module paths if different.
-	"battle_chess_poc/internal/game"   // your engine: NewEngine(), SetSideConfig(...), etc.
+	"battle_chess_poc/internal/game" // your engine: NewEngine(), SetSideConfig(...), etc.
+	_ "battle_chess_poc/internal/game/abilities"
 	"battle_chess_poc/internal/httpx"  // your HTTP server wrapper exposing Listen(engine) or similar
 	"battle_chess_poc/internal/shared" // enums + parsers (Ability, Element, ParseAbility/ParseElement, *Strings)  // <-- from abilities.go/types.go
 )

--- a/chessTest/internal/game/abilities/handler.go
+++ b/chessTest/internal/game/abilities/handler.go
@@ -162,3 +162,16 @@ func registeredAbilities() []shared.Ability {
 	}
 	return out
 }
+
+func init() {
+	game.RegisterAbilityFactory(func(id game.Ability) (game.AbilityHandler, error) {
+		handler, err := New(shared.Ability(id))
+		if err != nil {
+			if errors.Is(err, ErrUnknownAbility) {
+				return nil, game.ErrAbilityNotRegistered
+			}
+			return nil, err
+		}
+		return handler, nil
+	})
+}

--- a/chessTest/internal/game/ability_registry.go
+++ b/chessTest/internal/game/ability_registry.go
@@ -1,0 +1,24 @@
+package game
+
+import "errors"
+
+var (
+	abilityFactory func(Ability) (AbilityHandler, error)
+
+	// ErrAbilityFactoryNotConfigured indicates no resolver has been registered.
+	ErrAbilityFactoryNotConfigured = errors.New("game: ability factory not configured")
+	// ErrAbilityNotRegistered indicates the resolver does not have a handler for the ability.
+	ErrAbilityNotRegistered = errors.New("game: ability handler not registered")
+)
+
+// RegisterAbilityFactory installs the resolver used to construct ability handlers at runtime.
+func RegisterAbilityFactory(factory func(Ability) (AbilityHandler, error)) {
+	abilityFactory = factory
+}
+
+func resolveAbilityHandler(id Ability) (AbilityHandler, error) {
+	if abilityFactory == nil {
+		return nil, ErrAbilityFactoryNotConfigured
+	}
+	return abilityFactory(id)
+}

--- a/chessTest/internal/game/moves_test.go
+++ b/chessTest/internal/game/moves_test.go
@@ -7,6 +7,12 @@ import (
 	"testing"
 )
 
+func init() {
+	RegisterAbilityFactory(func(Ability) (AbilityHandler, error) {
+		return nil, ErrAbilityNotRegistered
+	})
+}
+
 func TestSliderOpeningMovesDoNotPanic(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -979,7 +985,7 @@ func TestBelligerentDoesNotIncreaseStepBudget(t *testing.T) {
 	eng.board.turn = White
 
 	pc := eng.board.pieceAt[start]
-	if steps := eng.calculateStepBudget(pc); steps != 1 {
+	if steps := eng.baseStepBudget(pc); steps != 1 {
 		t.Fatalf("expected belligerent to leave step budget at 1, got %d", steps)
 	}
 
@@ -1047,7 +1053,7 @@ func TestResurrectionCaptureWindowExpires(t *testing.T) {
 	eng.placePiece(Black, Queen, blocked)
 	eng.board.turn = White
 
-	if steps := eng.calculateStepBudget(eng.board.pieceAt[start]); steps < 3 {
+	if steps := eng.baseStepBudget(eng.board.pieceAt[start]); steps < 3 {
 		t.Fatalf("expected at least 3 steps with buffs, got %d", steps)
 	}
 	if eng.abilities[Black.Index()].Contains(AbilityDoOver) {


### PR DESCRIPTION
## Summary
- add an engine-level ability handler registry and register the concrete factories from the abilities package
- resolve active ability handlers when a move starts and dispatch lifecycle hooks for move/segment/capture events with step-budget and phasing overrides
- gate existing inline Blaze Rush/Flood Wake/Chain Kill fallbacks when handlers are available and ensure entry points load or stub the registry

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dae345b1d88323a925cb7a90cbecae