### PR TITLE
Refactor post-segment ability hooks

### DIFF
--- a/chessTest/internal/game/abilities/handler.go
+++ b/chessTest/internal/game/abilities/handler.go
@@ -42,11 +42,14 @@ type HandlerFuncs struct {
 	CanPhaseFunc           func(game.PhaseContext) (bool, error)
 	OnMoveStartFunc        func(game.MoveLifecycleContext) error
 	OnSegmentStartFunc     func(game.SegmentContext) error
+	OnPostSegmentFunc      func(game.PostSegmentContext) error
 	PrepareSegmentFunc     func(*game.SegmentPreparationContext) error
 	OnSegmentResolvedFunc  func(game.SegmentResolutionContext) error
 	OnCaptureFunc          func(game.CaptureContext) error
 	OnTurnEndFunc          func(game.TurnEndContext) error
 	PlanSpecialMoveFunc    func(*game.SpecialMoveContext) (game.SpecialMovePlan, bool, error)
+	FreeContinuationFunc   func(game.FreeContinuationContext) bool
+	OnDirectionChangeFunc  func(game.DirectionChangeContext) bool
 }
 
 // StepBudgetModifier invokes the configured modifier hook if present.
@@ -79,6 +82,14 @@ func (hf HandlerFuncs) OnSegmentStart(ctx game.SegmentContext) error {
 		return nil
 	}
 	return hf.OnSegmentStartFunc(ctx)
+}
+
+// OnPostSegment invokes the configured post-segment hook if present.
+func (hf HandlerFuncs) OnPostSegment(ctx game.PostSegmentContext) error {
+	if hf.OnPostSegmentFunc == nil {
+		return nil
+	}
+	return hf.OnPostSegmentFunc(ctx)
 }
 
 // PrepareSegment invokes the configured segment-preparation hook if present.
@@ -119,6 +130,22 @@ func (hf HandlerFuncs) PlanSpecialMove(ctx *game.SpecialMoveContext) (game.Speci
 		return game.SpecialMovePlan{}, false, nil
 	}
 	return hf.PlanSpecialMoveFunc(ctx)
+}
+
+// FreeContinuationAvailable invokes the configured continuation hook if present.
+func (hf HandlerFuncs) FreeContinuationAvailable(ctx game.FreeContinuationContext) bool {
+	if hf.FreeContinuationFunc == nil {
+		return false
+	}
+	return hf.FreeContinuationFunc(ctx)
+}
+
+// OnDirectionChange invokes the configured direction-change hook if present.
+func (hf HandlerFuncs) OnDirectionChange(ctx game.DirectionChangeContext) bool {
+	if hf.OnDirectionChangeFunc == nil {
+		return false
+	}
+	return hf.OnDirectionChangeFunc(ctx)
 }
 
 var (

--- a/chessTest/internal/game/ability_fallbacks.go
+++ b/chessTest/internal/game/ability_fallbacks.go
@@ -1,0 +1,122 @@
+package game
+
+// abilityHandlerBase provides default implementations for AbilityHandler
+// methods that many fallback handlers do not need to customise.
+type abilityHandlerBase struct{}
+
+func (abilityHandlerBase) StepBudgetModifier(StepBudgetContext) (StepBudgetDelta, error) {
+	return StepBudgetDelta{}, nil
+}
+
+func (abilityHandlerBase) CanPhase(PhaseContext) (bool, error) {
+	return false, nil
+}
+
+func (abilityHandlerBase) OnMoveStart(MoveLifecycleContext) error {
+	return nil
+}
+
+func (abilityHandlerBase) OnSegmentStart(SegmentContext) error {
+	return nil
+}
+
+func (abilityHandlerBase) OnPostSegment(PostSegmentContext) error {
+	return nil
+}
+
+func (abilityHandlerBase) OnCapture(CaptureContext) error {
+	return nil
+}
+
+func (abilityHandlerBase) OnTurnEnd(TurnEndContext) error {
+	return nil
+}
+
+// newBlazeRushFallbackHandler returns a default handler that mirrors the
+// existing Blaze Rush behaviour for engines without a registered handler.
+func newBlazeRushFallbackHandler() AbilityHandler {
+	return blazeRushFallbackHandler{}
+}
+
+type blazeRushFallbackHandler struct {
+	abilityHandlerBase
+}
+
+func (blazeRushFallbackHandler) OnPostSegment(ctx PostSegmentContext) error {
+	if ctx.Engine == nil || ctx.Move == nil || ctx.Piece == nil {
+		return nil
+	}
+	if ctx.Engine.isBlazeRushDash(ctx.Piece, ctx.From, ctx.To, ctx.Segment.Capture) {
+		ctx.Move.markAbilityUsed(AbilityBlazeRush)
+		appendAbilityNote(&ctx.Engine.board.lastNote, "Blaze Rush dash (free)")
+	}
+	return nil
+}
+
+func (blazeRushFallbackHandler) FreeContinuationAvailable(ctx FreeContinuationContext) bool {
+	if ctx.Engine == nil || ctx.Piece == nil {
+		return false
+	}
+	return ctx.Engine.blazeRushContinuationAvailable(ctx.Piece)
+}
+
+// newFloodWakeFallbackHandler returns a default handler that mirrors the
+// existing Flood Wake behaviour for engines without a registered handler.
+func newFloodWakeFallbackHandler() AbilityHandler {
+	return floodWakeFallbackHandler{}
+}
+
+type floodWakeFallbackHandler struct {
+	abilityHandlerBase
+}
+
+func (floodWakeFallbackHandler) OnPostSegment(ctx PostSegmentContext) error {
+	if ctx.Engine == nil || ctx.Move == nil || ctx.Piece == nil {
+		return nil
+	}
+	if ctx.Engine.isFloodWakePushAvailable(ctx.Piece, ctx.From, ctx.To, ctx.Segment.Capture) {
+		ctx.Move.markAbilityUsed(AbilityFloodWake)
+		appendAbilityNote(&ctx.Engine.board.lastNote, "Flood Wake push (free)")
+	}
+	return nil
+}
+
+func (floodWakeFallbackHandler) FreeContinuationAvailable(ctx FreeContinuationContext) bool {
+	if ctx.Engine == nil || ctx.Piece == nil {
+		return false
+	}
+	return ctx.Engine.floodWakeContinuationAvailable(ctx.Piece)
+}
+
+// newMistShroudFallbackHandler returns a default handler that mirrors the
+// existing Mist Shroud behaviour for engines without a registered handler.
+func newMistShroudFallbackHandler() AbilityHandler {
+	return mistShroudFallbackHandler{}
+}
+
+type mistShroudFallbackHandler struct {
+	abilityHandlerBase
+}
+
+func (mistShroudFallbackHandler) OnDirectionChange(ctx DirectionChangeContext) bool {
+	if ctx.Engine == nil || ctx.Move == nil || ctx.Piece == nil {
+		return false
+	}
+	if !ctx.Piece.Abilities.Contains(AbilityMistShroud) {
+		return false
+	}
+	if ctx.Move.abilityCounter(AbilityMistShroud, abilityCounterFree) != 0 {
+		return false
+	}
+	ctx.Move.addAbilityCounter(AbilityMistShroud, abilityCounterFree, 1)
+	appendAbilityNote(&ctx.Engine.board.lastNote, "Mist Shroud free pivot")
+	return true
+}
+
+// Ensure the fallback handler satisfies optional interfaces used by the
+// dispatcher without exposing additional methods.
+var (
+	_ FreeContinuationHandler = blazeRushFallbackHandler{}
+	_ FreeContinuationHandler = floodWakeFallbackHandler{}
+	_ DirectionChangeHandler  = mistShroudFallbackHandler{}
+)


### PR DESCRIPTION
## Summary
- add post-segment, direction-change, and continuation handler hooks with supporting contexts
- introduce built-in fallback handlers for Blaze Rush, Flood Wake, and Mist Shroud to manage state and notes
- route move post-processing and continuation checks through the handler pipeline

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68daef4cf93c832381d86aaf9c0c0fc1