### PR TITLE
Refactor capture resolution into ability handlers

### DIFF
--- a/chessTest/internal/game/abilities/builtins.go
+++ b/chessTest/internal/game/abilities/builtins.go
@@ -1,0 +1,22 @@
+package abilities
+
+import (
+	"battle_chess_poc/internal/game"
+	"battle_chess_poc/internal/shared"
+)
+
+func init() {
+	mustRegisterBuiltin(shared.AbilityDoubleKill, game.NewDoubleKillHandler)
+	mustRegisterBuiltin(shared.AbilityScorch, game.NewScorchHandler)
+	mustRegisterBuiltin(shared.AbilityQuantumKill, game.NewQuantumKillHandler)
+	mustRegisterBuiltin(shared.AbilityPoisonousMeat, game.NewPoisonousMeatHandler)
+	mustRegisterBuiltin(shared.AbilityOverload, game.NewOverloadHandler)
+	mustRegisterBuiltin(shared.AbilityBastion, game.NewBastionHandler)
+	mustRegisterBuiltin(shared.AbilityTemporalLock, game.NewTemporalLockHandler)
+}
+
+func mustRegisterBuiltin(id shared.Ability, ctor func() game.AbilityHandler) {
+	if err := Register(id, func() AbilityHandler { return ctor() }); err != nil {
+		panic(err)
+	}
+}

--- a/chessTest/internal/game/abilities/handler.go
+++ b/chessTest/internal/game/abilities/handler.go
@@ -47,6 +47,8 @@ type HandlerFuncs struct {
 	OnSegmentResolvedFunc  func(game.SegmentResolutionContext) error
 	OnCaptureFunc          func(game.CaptureContext) error
 	OnTurnEndFunc          func(game.TurnEndContext) error
+	ResolveCaptureFunc     func(game.CaptureContext) (game.CaptureOutcome, error)
+	ResolveTurnEndFunc     func(game.TurnEndContext) (game.TurnEndOutcome, error)
 	PlanSpecialMoveFunc    func(*game.SpecialMoveContext) (game.SpecialMovePlan, bool, error)
 	FreeContinuationFunc   func(game.FreeContinuationContext) bool
 	OnDirectionChangeFunc  func(game.DirectionChangeContext) bool
@@ -122,6 +124,22 @@ func (hf HandlerFuncs) OnTurnEnd(ctx game.TurnEndContext) error {
 		return nil
 	}
 	return hf.OnTurnEndFunc(ctx)
+}
+
+// ResolveCapture invokes the configured capture-resolution hook if present.
+func (hf HandlerFuncs) ResolveCapture(ctx game.CaptureContext) (game.CaptureOutcome, error) {
+	if hf.ResolveCaptureFunc == nil {
+		return game.CaptureOutcome{}, nil
+	}
+	return hf.ResolveCaptureFunc(ctx)
+}
+
+// ResolveTurnEnd invokes the configured turn-end resolution hook if present.
+func (hf HandlerFuncs) ResolveTurnEnd(ctx game.TurnEndContext) (game.TurnEndOutcome, error) {
+	if hf.ResolveTurnEndFunc == nil {
+		return game.TurnEndOutcome{}, nil
+	}
+	return hf.ResolveTurnEndFunc(ctx)
 }
 
 // PlanSpecialMove invokes the configured special-move planner if present.

--- a/chessTest/internal/game/ability_capture_handlers.go
+++ b/chessTest/internal/game/ability_capture_handlers.go
@@ -1,0 +1,222 @@
+package game
+
+import "fmt"
+
+// NewDoubleKillHandler constructs the default Double Kill ability handler.
+func NewDoubleKillHandler() AbilityHandler { return doubleKillHandler{} }
+
+type doubleKillHandler struct {
+	abilityHandlerBase
+}
+
+func (doubleKillHandler) ResolveCapture(ctx CaptureContext) (CaptureOutcome, error) {
+	if ctx.Engine == nil || ctx.Attacker == nil || ctx.Victim == nil {
+		return CaptureOutcome{}, nil
+	}
+	attacker := ctx.Attacker
+	if !attacker.Abilities.Contains(AbilityDoubleKill) {
+		return CaptureOutcome{}, nil
+	}
+	target := ctx.Engine.trySmartExtraCapture(attacker, ctx.CaptureSquare, ctx.Victim.Color, rankOf(ctx.Victim.Type))
+	if target == nil {
+		return CaptureOutcome{}, nil
+	}
+	targetSquare := target.Square
+	removed, err := ctx.Engine.attemptAbilityRemoval(attacker, target)
+	if err != nil {
+		return CaptureOutcome{}, err
+	}
+	if !removed {
+		return CaptureOutcome{}, nil
+	}
+	appendAbilityNote(&ctx.Engine.board.lastNote, fmt.Sprintf("DoubleKill: removed %s %s at %s", target.Color, target.Type, targetSquare))
+	if ctx.Move != nil {
+		ctx.Move.setAbilityFlag(AbilityNone, abilityFlagCaptureExtra, true)
+	}
+	return CaptureOutcome{}, nil
+}
+
+// NewScorchHandler constructs the default Scorch ability handler.
+func NewScorchHandler() AbilityHandler { return scorchHandler{} }
+
+type scorchHandler struct {
+	abilityHandlerBase
+}
+
+func (scorchHandler) ResolveCapture(ctx CaptureContext) (CaptureOutcome, error) {
+	if ctx.Engine == nil || ctx.Attacker == nil || ctx.Victim == nil || ctx.Move == nil {
+		return CaptureOutcome{}, nil
+	}
+	attacker := ctx.Attacker
+	if !attacker.Abilities.Contains(AbilityScorch) {
+		return CaptureOutcome{}, nil
+	}
+	if ctx.Move.abilityFlag(AbilityNone, abilityFlagCaptureExtra) {
+		return CaptureOutcome{}, nil
+	}
+	if elementOf(ctx.Engine, attacker) != ElementFire {
+		return CaptureOutcome{}, nil
+	}
+	target := ctx.Engine.trySmartExtraCapture(attacker, ctx.CaptureSquare, ctx.Victim.Color, rankOf(ctx.Victim.Type))
+	if target == nil {
+		return CaptureOutcome{}, nil
+	}
+	targetSquare := target.Square
+	removed, err := ctx.Engine.attemptAbilityRemoval(attacker, target)
+	if err != nil {
+		return CaptureOutcome{}, err
+	}
+	if !removed {
+		return CaptureOutcome{}, nil
+	}
+	appendAbilityNote(&ctx.Engine.board.lastNote, fmt.Sprintf("Fire Scorch: removed %s %s at %s", target.Color, target.Type, targetSquare))
+	ctx.Move.setAbilityFlag(AbilityNone, abilityFlagCaptureExtra, true)
+	return CaptureOutcome{}, nil
+}
+
+// NewQuantumKillHandler constructs the default Quantum Kill ability handler.
+func NewQuantumKillHandler() AbilityHandler { return quantumKillHandler{} }
+
+type quantumKillHandler struct {
+	abilityHandlerBase
+}
+
+func (quantumKillHandler) ResolveCapture(ctx CaptureContext) (CaptureOutcome, error) {
+	if ctx.Engine == nil || ctx.Attacker == nil || ctx.Victim == nil || ctx.Move == nil {
+		return CaptureOutcome{}, nil
+	}
+	attacker := ctx.Attacker
+	if !attacker.Abilities.Contains(AbilityQuantumKill) {
+		return CaptureOutcome{}, nil
+	}
+	if ctx.Move.abilityUsed(AbilityQuantumKill) {
+		return CaptureOutcome{}, nil
+	}
+	ctx.Move.markAbilityUsed(AbilityQuantumKill)
+	victimColor := ctx.Victim.Color
+	victimRank := rankOf(ctx.Victim.Type)
+	target := ctx.Engine.findQuantumKillTarget(attacker, victimColor, victimRank)
+	if target == nil {
+		return CaptureOutcome{}, nil
+	}
+	targetSquare := target.Square
+	removed, err := ctx.Engine.attemptAbilityRemoval(attacker, target)
+	if err != nil {
+		return CaptureOutcome{}, err
+	}
+	if !removed {
+		return CaptureOutcome{}, nil
+	}
+	appendAbilityNote(&ctx.Engine.board.lastNote, fmt.Sprintf("Quantum Kill: removed %s %s at %s", target.Color, target.Type, targetSquare))
+	if echo := ctx.Engine.trySmartExtraCapture(attacker, targetSquare, victimColor, rankOf(target.Type)); echo != nil {
+		echoSquare := echo.Square
+		removedEcho, err := ctx.Engine.attemptAbilityRemoval(attacker, echo)
+		if err != nil {
+			return CaptureOutcome{}, err
+		}
+		if removedEcho {
+			appendAbilityNote(&ctx.Engine.board.lastNote, fmt.Sprintf("Quantum Echo: removed %s %s at %s", echo.Color, echo.Type, echoSquare))
+		}
+	}
+	return CaptureOutcome{}, nil
+}
+
+// NewPoisonousMeatHandler constructs the default Poisonous Meat ability handler.
+func NewPoisonousMeatHandler() AbilityHandler { return poisonousMeatHandler{} }
+
+type poisonousMeatHandler struct {
+	abilityHandlerBase
+}
+
+func (poisonousMeatHandler) ResolveCapture(ctx CaptureContext) (CaptureOutcome, error) {
+	if ctx.Engine == nil || ctx.Attacker == nil || ctx.Move == nil {
+		return CaptureOutcome{}, nil
+	}
+	attacker := ctx.Attacker
+	if !attacker.Abilities.Contains(AbilityPoisonousMeat) {
+		return CaptureOutcome{}, nil
+	}
+	outcome := CaptureOutcome{ForceTurnEnd: true}
+	if elementOf(ctx.Engine, attacker) != ElementShadow && ctx.Move.RemainingSteps > 0 {
+		outcome.StepAdjustment = -1
+		appendAbilityNote(&ctx.Engine.board.lastNote, "Poisonous Meat drains 1 step")
+	}
+	appendAbilityNote(&ctx.Engine.board.lastNote, "Poisonous Meat ends the turn")
+	return outcome, nil
+}
+
+// NewOverloadHandler constructs the default Overload ability handler.
+func NewOverloadHandler() AbilityHandler { return overloadHandler{} }
+
+type overloadHandler struct {
+	abilityHandlerBase
+}
+
+func (overloadHandler) ResolveCapture(ctx CaptureContext) (CaptureOutcome, error) {
+	if ctx.Engine == nil || ctx.Attacker == nil || ctx.Move == nil {
+		return CaptureOutcome{}, nil
+	}
+	attacker := ctx.Attacker
+	if !attacker.Abilities.Contains(AbilityOverload) {
+		return CaptureOutcome{}, nil
+	}
+	element := elementOf(ctx.Engine, attacker)
+	outcome := CaptureOutcome{}
+	if attacker.Abilities.Contains(AbilityStalwart) && element == ElementLightning && ctx.Move.RemainingSteps > 0 {
+		outcome.StepAdjustment = -1
+		appendAbilityNote(&ctx.Engine.board.lastNote, "Overload + Stalwart costs 1 step")
+	}
+	if element == ElementLightning {
+		outcome.ForceTurnEnd = true
+		appendAbilityNote(&ctx.Engine.board.lastNote, "Overload ends the turn")
+	}
+	return outcome, nil
+}
+
+// NewBastionHandler constructs the default Bastion ability handler.
+func NewBastionHandler() AbilityHandler { return bastionHandler{} }
+
+type bastionHandler struct {
+	abilityHandlerBase
+}
+
+func (bastionHandler) ResolveCapture(ctx CaptureContext) (CaptureOutcome, error) {
+	if ctx.Engine == nil || ctx.Attacker == nil {
+		return CaptureOutcome{}, nil
+	}
+	attacker := ctx.Attacker
+	if !attacker.Abilities.Contains(AbilityBastion) {
+		return CaptureOutcome{}, nil
+	}
+	if elementOf(ctx.Engine, attacker) != ElementEarth {
+		return CaptureOutcome{}, nil
+	}
+	appendAbilityNote(&ctx.Engine.board.lastNote, "Bastion ends the turn")
+	return CaptureOutcome{ForceTurnEnd: true}, nil
+}
+
+// NewTemporalLockHandler constructs the default Temporal Lock ability handler.
+func NewTemporalLockHandler() AbilityHandler { return temporalLockHandler{} }
+
+type temporalLockHandler struct {
+	abilityHandlerBase
+}
+
+func (temporalLockHandler) ResolveTurnEnd(ctx TurnEndContext) (TurnEndOutcome, error) {
+	if ctx.Engine == nil || ctx.Move == nil || ctx.Move.Piece == nil {
+		return TurnEndOutcome{}, nil
+	}
+	pc := ctx.Move.Piece
+	if !pc.Abilities.Contains(AbilityTemporalLock) {
+		return TurnEndOutcome{}, nil
+	}
+	slow := 1
+	if elementOf(ctx.Engine, pc) == ElementFire {
+		slow = 2
+	}
+	opponent := pc.Color.Opposite()
+	outcome := TurnEndOutcome{}
+	outcome.AddSlow(opponent, slow)
+	outcome.Notes = append(outcome.Notes, fmt.Sprintf("Temporal Lock slows %s by %d", opponent, slow))
+	return outcome, nil
+}

--- a/chessTest/internal/game/ability_fallbacks.go
+++ b/chessTest/internal/game/ability_fallbacks.go
@@ -32,6 +32,14 @@ func (abilityHandlerBase) OnTurnEnd(TurnEndContext) error {
 	return nil
 }
 
+func (abilityHandlerBase) ResolveCapture(CaptureContext) (CaptureOutcome, error) {
+	return CaptureOutcome{}, nil
+}
+
+func (abilityHandlerBase) ResolveTurnEnd(TurnEndContext) (TurnEndOutcome, error) {
+	return TurnEndOutcome{}, nil
+}
+
 // newBlazeRushFallbackHandler returns a default handler that mirrors the
 // existing Blaze Rush behaviour for engines without a registered handler.
 func newBlazeRushFallbackHandler() AbilityHandler {


### PR DESCRIPTION
## Summary
- dispatch capture aftermath through ability handlers, collecting standardized outcomes for extra removals, step drains, and forced turn endings
- implement built-in handlers for Double Kill, Scorch, Quantum Kill, Poisonous Meat, Overload, Bastion, and Temporal Lock with automatic fallback registration
- apply handler-provided cleanup during end-of-turn processing and refresh the documentation to describe the new flow

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68daf279ce648323b9580944d5e0c4d2