### PR TITLE
Delegate movement checks to ability handlers

### DIFF
--- a/chessTest/internal/game/ability_runtime.go
+++ b/chessTest/internal/game/ability_runtime.go
@@ -198,6 +198,26 @@ type CaptureOutcome struct {
 	ForceTurnEnd   bool
 }
 
+// ResurrectionContext captures the runtime data needed for handlers managing
+// Resurrection windows.
+type ResurrectionContext struct {
+	Engine *Engine
+	Move   *MoveState
+	Piece  *Piece
+}
+
+// ResurrectionWindowHandler allows abilities to expose whether the
+// resurrection capture window is currently active.
+type ResurrectionWindowHandler interface {
+	ResurrectionWindowActive(ctx ResurrectionContext) bool
+}
+
+// ResurrectionCaptureWindowHandler lets abilities contribute capture squares
+// while the resurrection window is live.
+type ResurrectionCaptureWindowHandler interface {
+	AddResurrectionCaptureWindow(ctx ResurrectionContext, moves Bitboard) Bitboard
+}
+
 // Merge combines the receiver with another outcome, accumulating step deltas
 // and preserving any forced turn termination requests.
 func (o CaptureOutcome) Merge(other CaptureOutcome) CaptureOutcome {


### PR DESCRIPTION
## Summary
- extend the step budget pass to include handler-provided adjustments alongside the base calculation
- consult ability handlers (including side-level fallbacks) when determining whether a piece can phase through blockers
- expose resurrection handler hooks and let the engine query them before falling back to legacy MoveState flags

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dafb19e6488323a0c56e199d74a327