### PR TITLE
Implement handler runtime for Chain Kill and Resurrection

### DIFF
--- a/chessTest/internal/game/abilities/builtins.go
+++ b/chessTest/internal/game/abilities/builtins.go
@@ -9,10 +9,12 @@ func init() {
 	mustRegisterBuiltin(shared.AbilityDoubleKill, game.NewDoubleKillHandler)
 	mustRegisterBuiltin(shared.AbilityScorch, game.NewScorchHandler)
 	mustRegisterBuiltin(shared.AbilityQuantumKill, game.NewQuantumKillHandler)
+	mustRegisterBuiltin(shared.AbilityChainKill, game.NewChainKillHandler)
 	mustRegisterBuiltin(shared.AbilityPoisonousMeat, game.NewPoisonousMeatHandler)
 	mustRegisterBuiltin(shared.AbilityOverload, game.NewOverloadHandler)
 	mustRegisterBuiltin(shared.AbilityBastion, game.NewBastionHandler)
 	mustRegisterBuiltin(shared.AbilityTemporalLock, game.NewTemporalLockHandler)
+	mustRegisterBuiltin(shared.AbilityResurrection, game.NewResurrectionHandler)
 }
 
 func mustRegisterBuiltin(id shared.Ability, ctor func() game.AbilityHandler) {

--- a/chessTest/internal/game/ability_chain_kill_handler.go
+++ b/chessTest/internal/game/ability_chain_kill_handler.go
@@ -1,0 +1,19 @@
+package game
+
+// NewChainKillHandler constructs the default Chain Kill ability handler.
+func NewChainKillHandler() AbilityHandler { return &chainKillHandler{} }
+
+type chainKillHandler struct {
+	abilityHandlerBase
+}
+
+func (chainKillHandler) OnMoveStart(ctx MoveLifecycleContext) error {
+	if ctx.Move == nil {
+		return nil
+	}
+	// Chain Kill grants two additional captures beyond the base allowance.
+	ctx.Move.increaseCaptureLimit(2)
+	return nil
+}
+
+var _ AbilityHandler = (*chainKillHandler)(nil)

--- a/chessTest/internal/game/ability_resolver.go
+++ b/chessTest/internal/game/ability_resolver.go
@@ -17,7 +17,7 @@ func (e *Engine) ResolveCaptureAbility(attacker, victim *Piece, captureSquare Sq
 	}
 
 	if e.currentMove != nil {
-		e.currentMove.setAbilityFlag(AbilityNone, abilityFlagCaptureExtra, false)
+		e.currentMove.resetExtraRemoval()
 	}
 
 	outcome, err := e.dispatchCaptureResolutionHandlers(attacker, victim, captureSquare, segmentStep)

--- a/chessTest/internal/game/ability_resurrection_handler.go
+++ b/chessTest/internal/game/ability_resurrection_handler.go
@@ -1,0 +1,103 @@
+package game
+
+import "battle_chess_poc/internal/shared"
+
+// NewResurrectionHandler constructs the default Resurrection ability handler.
+func NewResurrectionHandler() AbilityHandler { return &resurrectionHandler{} }
+
+type resurrectionHandler struct {
+	abilityHandlerBase
+}
+
+func (resurrectionHandler) OnMoveStart(ctx MoveLifecycleContext) error {
+	resetResurrectionState(ctx.Move)
+	return nil
+}
+
+func (resurrectionHandler) OnCapture(ctx CaptureContext) error {
+	if ctx.Move == nil || ctx.Attacker == nil {
+		return nil
+	}
+	if ctx.Move.Piece != nil && ctx.Move.Piece != ctx.Attacker {
+		return nil
+	}
+	ctx.Move.setAbilityFlag(AbilityResurrection, abilityFlagWindow, true)
+	ctx.Move.setAbilityCounter(AbilityResurrection, abilityCounterResurrectionHold, 0)
+	return nil
+}
+
+func (resurrectionHandler) OnSegmentStart(ctx SegmentContext) error {
+	if ctx.Move == nil {
+		return nil
+	}
+	if !ctx.Move.abilityFlag(AbilityResurrection, abilityFlagWindow) {
+		return nil
+	}
+	if ctx.Move.abilityCounter(AbilityResurrection, abilityCounterResurrectionHold) != 0 {
+		return nil
+	}
+	ctx.Move.setAbilityCounter(AbilityResurrection, abilityCounterResurrectionHold, 1)
+	return nil
+}
+
+func (resurrectionHandler) OnSegmentResolved(ctx SegmentResolutionContext) error {
+	if ctx.Move == nil {
+		return nil
+	}
+	if ctx.Move.abilityCounter(AbilityResurrection, abilityCounterResurrectionHold) == 0 {
+		return nil
+	}
+	ctx.Move.setAbilityCounter(AbilityResurrection, abilityCounterResurrectionHold, 0)
+	ctx.Move.setAbilityFlag(AbilityResurrection, abilityFlagWindow, false)
+	return nil
+}
+
+func (resurrectionHandler) OnTurnEnd(ctx TurnEndContext) error {
+	resetResurrectionState(ctx.Move)
+	return nil
+}
+
+func (resurrectionHandler) ResurrectionWindowActive(ctx ResurrectionContext) bool {
+	if ctx.Move == nil || ctx.Piece == nil {
+		return false
+	}
+	if ctx.Move.Piece != nil && ctx.Move.Piece != ctx.Piece {
+		return false
+	}
+	return ctx.Move.abilityFlag(AbilityResurrection, abilityFlagWindow)
+}
+
+func (resurrectionHandler) AddResurrectionCaptureWindow(ctx ResurrectionContext, moves Bitboard) Bitboard {
+	if !(resurrectionHandler{}).ResurrectionWindowActive(ctx) {
+		return moves
+	}
+	if ctx.Engine == nil || ctx.Piece == nil {
+		return moves
+	}
+	from := ctx.Piece.Square
+	rank := from.Rank()
+	file := from.File()
+	for _, dr := range []int{-1, 1} {
+		if target, ok := shared.SquareFromCoords(rank+dr, file); ok {
+			occupant := ctx.Engine.board.pieceAt[target]
+			if occupant != nil && occupant.Color != ctx.Piece.Color && ctx.Engine.canDirectCapture(ctx.Piece, occupant, from, target) {
+				moves = moves.Add(target)
+			}
+		}
+	}
+	return moves
+}
+
+func resetResurrectionState(move *MoveState) {
+	if move == nil {
+		return
+	}
+	move.setAbilityFlag(AbilityResurrection, abilityFlagWindow, false)
+	move.setAbilityCounter(AbilityResurrection, abilityCounterResurrectionHold, 0)
+}
+
+var (
+	_ AbilityHandler                   = (*resurrectionHandler)(nil)
+	_ ResurrectionWindowHandler        = (*resurrectionHandler)(nil)
+	_ ResurrectionCaptureWindowHandler = (*resurrectionHandler)(nil)
+)


### PR DESCRIPTION
## Summary
- add dedicated Chain Kill and Resurrection handlers that manage capture limits and resurrection windows through MoveState runtime
- centralize capture-limit bookkeeping and extra-removal tracking on MoveState and simplify continuation logic
- update capture handlers and ability registration to cooperate with the new runtime behaviour

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dafdfcc6cc832381f5c2ab97d21201