### PR TITLE
Add step budget and phasing ability handlers

### DIFF
--- a/chessTest/internal/game/abilities/builtins.go
+++ b/chessTest/internal/game/abilities/builtins.go
@@ -8,6 +8,11 @@ import (
 func init() {
 	mustRegisterBuiltin(shared.AbilityDoubleKill, game.NewDoubleKillHandler)
 	mustRegisterBuiltin(shared.AbilityScorch, game.NewScorchHandler)
+	mustRegisterBuiltin(shared.AbilityTailwind, game.NewTailwindHandler)
+	mustRegisterBuiltin(shared.AbilityRadiantVision, game.NewRadiantVisionHandler)
+	mustRegisterBuiltin(shared.AbilityUmbralStep, game.NewUmbralStepHandler)
+	mustRegisterBuiltin(shared.AbilitySchrodingersLaugh, game.NewSchrodingersLaughHandler)
+	mustRegisterBuiltin(shared.AbilityGaleLift, game.NewGaleLiftHandler)
 	mustRegisterBuiltin(shared.AbilityQuantumKill, game.NewQuantumKillHandler)
 	mustRegisterBuiltin(shared.AbilityChainKill, game.NewChainKillHandler)
 	mustRegisterBuiltin(shared.AbilityPoisonousMeat, game.NewPoisonousMeatHandler)

--- a/chessTest/internal/game/abilities/handler.go
+++ b/chessTest/internal/game/abilities/handler.go
@@ -34,6 +34,10 @@ const (
 	TurnEndCancelled = game.TurnEndCancelled
 )
 
+var (
+	ErrPhaseDenied = game.ErrPhaseDenied
+)
+
 // HandlerFuncs provides a convenient adapter that allows handlers to override
 // only the hooks they need. Any nil function pointer results in a neutral
 // response so the registry can safely skip unused hooks.

--- a/chessTest/internal/game/ability_capture_handlers.go
+++ b/chessTest/internal/game/ability_capture_handlers.go
@@ -41,6 +41,20 @@ type scorchHandler struct {
 	abilityHandlerBase
 }
 
+func (scorchHandler) StepBudgetModifier(ctx StepBudgetContext) (StepBudgetDelta, error) {
+	if ctx.Engine == nil || ctx.Piece == nil {
+		return StepBudgetDelta{}, nil
+	}
+	pc := ctx.Piece
+	if !pc.Abilities.Contains(AbilityScorch) {
+		return StepBudgetDelta{}, nil
+	}
+	if elementOf(ctx.Engine, pc) != ElementFire {
+		return StepBudgetDelta{}, nil
+	}
+	return StepBudgetDelta{AddSteps: 1, Notes: []string{"Scorch grants +1 step"}}, nil
+}
+
 func (scorchHandler) ResolveCapture(ctx CaptureContext) (CaptureOutcome, error) {
 	if ctx.Engine == nil || ctx.Attacker == nil || ctx.Victim == nil || ctx.Move == nil {
 		return CaptureOutcome{}, nil
@@ -170,6 +184,10 @@ func NewBastionHandler() AbilityHandler { return bastionHandler{} }
 
 type bastionHandler struct {
 	abilityHandlerBase
+}
+
+func (bastionHandler) CanPhase(PhaseContext) (bool, error) {
+	return false, ErrPhaseDenied
 }
 
 func (bastionHandler) ResolveCapture(ctx CaptureContext) (CaptureOutcome, error) {

--- a/chessTest/internal/game/ability_fallbacks.go
+++ b/chessTest/internal/game/ability_fallbacks.go
@@ -99,6 +99,10 @@ type floodWakeFallbackHandler struct {
 	abilityHandlerBase
 }
 
+func (floodWakeFallbackHandler) CanPhase(PhaseContext) (bool, error) {
+	return false, ErrPhaseDenied
+}
+
 func (floodWakeFallbackHandler) PlanSpecialMove(ctx *SpecialMoveContext) (SpecialMovePlan, bool, error) {
 	return SpecialMovePlan{}, false, nil
 }

--- a/chessTest/internal/game/ability_runtime.go
+++ b/chessTest/internal/game/ability_runtime.go
@@ -1,6 +1,10 @@
 package game
 
-import "battle_chess_poc/internal/shared"
+import (
+	"errors"
+
+	"battle_chess_poc/internal/shared"
+)
 
 // AbilityHandler represents the lifecycle hooks that an ability can implement
 // to integrate with the engine. Handlers may implement any subset of the
@@ -197,6 +201,13 @@ type CaptureOutcome struct {
 	StepAdjustment int
 	ForceTurnEnd   bool
 }
+
+var (
+	// ErrPhaseDenied indicates an ability explicitly vetoed phasing for the
+	// active move. Handlers should return this sentinel via CanPhase to
+	// communicate a hard block that overrides any later grants.
+	ErrPhaseDenied = errors.New("game: phasing denied by ability")
+)
 
 // ResurrectionContext captures the runtime data needed for handlers managing
 // Resurrection windows.

--- a/chessTest/internal/game/ability_step_budget_handlers.go
+++ b/chessTest/internal/game/ability_step_budget_handlers.go
@@ -1,0 +1,133 @@
+package game
+
+// NewTailwindHandler constructs the default Tailwind ability handler.
+func NewTailwindHandler() AbilityHandler { return tailwindHandler{} }
+
+type tailwindHandler struct {
+	abilityHandlerBase
+}
+
+func (tailwindHandler) StepBudgetModifier(ctx StepBudgetContext) (StepBudgetDelta, error) {
+	if ctx.Engine == nil || ctx.Piece == nil {
+		return StepBudgetDelta{}, nil
+	}
+	pc := ctx.Piece
+	if !pc.Abilities.Contains(AbilityTailwind) {
+		return StepBudgetDelta{}, nil
+	}
+	if elementOf(ctx.Engine, pc) != ElementAir {
+		return StepBudgetDelta{}, nil
+	}
+
+	delta := StepBudgetDelta{AddSteps: 2, Notes: []string{"Tailwind grants +2 steps"}}
+	if pc.Abilities.Contains(AbilityTemporalLock) {
+		delta.AddSteps--
+		delta.Notes = append(delta.Notes, "Temporal Lock dampens Tailwind (-1 step)")
+	}
+	return delta, nil
+}
+
+// NewRadiantVisionHandler constructs the default Radiant Vision ability handler.
+func NewRadiantVisionHandler() AbilityHandler { return radiantVisionHandler{} }
+
+type radiantVisionHandler struct {
+	abilityHandlerBase
+}
+
+func (radiantVisionHandler) StepBudgetModifier(ctx StepBudgetContext) (StepBudgetDelta, error) {
+	if ctx.Engine == nil || ctx.Piece == nil {
+		return StepBudgetDelta{}, nil
+	}
+	pc := ctx.Piece
+	if !pc.Abilities.Contains(AbilityRadiantVision) {
+		return StepBudgetDelta{}, nil
+	}
+	if elementOf(ctx.Engine, pc) != ElementLight {
+		return StepBudgetDelta{}, nil
+	}
+
+	delta := StepBudgetDelta{AddSteps: 1, Notes: []string{"Radiant Vision grants +1 step"}}
+	if pc.Abilities.Contains(AbilityMistShroud) {
+		delta.AddSteps++
+		delta.Notes = append(delta.Notes, "Mist Shroud combo adds +1 step")
+	}
+	return delta, nil
+}
+
+// NewUmbralStepHandler constructs the default Umbral Step ability handler.
+func NewUmbralStepHandler() AbilityHandler { return umbralStepHandler{} }
+
+type umbralStepHandler struct {
+	abilityHandlerBase
+}
+
+func (umbralStepHandler) StepBudgetModifier(ctx StepBudgetContext) (StepBudgetDelta, error) {
+	if ctx.Engine == nil || ctx.Piece == nil {
+		return StepBudgetDelta{}, nil
+	}
+	pc := ctx.Piece
+	if !pc.Abilities.Contains(AbilityUmbralStep) {
+		return StepBudgetDelta{}, nil
+	}
+	if elementOf(ctx.Engine, pc) != ElementShadow {
+		return StepBudgetDelta{}, nil
+	}
+
+	delta := StepBudgetDelta{AddSteps: 2, Notes: []string{"Umbral Step grants +2 steps"}}
+	if pc.Abilities.Contains(AbilityRadiantVision) {
+		delta.AddSteps--
+		delta.Notes = append(delta.Notes, "Radiant Vision reduces Umbral Step by 1")
+	}
+	return delta, nil
+}
+
+func (umbralStepHandler) CanPhase(ctx PhaseContext) (bool, error) {
+	if ctx.Piece == nil {
+		return false, nil
+	}
+	if !ctx.Piece.Abilities.Contains(AbilityUmbralStep) {
+		return false, nil
+	}
+	return true, nil
+}
+
+// NewSchrodingersLaughHandler constructs the default Schrödinger's Laugh ability handler.
+func NewSchrodingersLaughHandler() AbilityHandler { return schrodingersLaughHandler{} }
+
+type schrodingersLaughHandler struct {
+	abilityHandlerBase
+}
+
+func (schrodingersLaughHandler) StepBudgetModifier(ctx StepBudgetContext) (StepBudgetDelta, error) {
+	if ctx.Piece == nil {
+		return StepBudgetDelta{}, nil
+	}
+	pc := ctx.Piece
+	if !pc.Abilities.Contains(AbilitySchrodingersLaugh) {
+		return StepBudgetDelta{}, nil
+	}
+
+	delta := StepBudgetDelta{AddSteps: 2, Notes: []string{"Schrödinger's Laugh grants +2 steps"}}
+	if pc.Abilities.Contains(AbilitySideStep) {
+		delta.AddSteps++
+		delta.Notes = append(delta.Notes, "Side Step combo adds +1 step")
+	}
+	return delta, nil
+}
+
+// NewGaleLiftHandler constructs the default Gale Lift ability handler.
+func NewGaleLiftHandler() AbilityHandler { return galeLiftHandler{} }
+
+type galeLiftHandler struct {
+	abilityHandlerBase
+}
+
+func (galeLiftHandler) CanPhase(ctx PhaseContext) (bool, error) {
+	if ctx.Piece == nil {
+		return false, nil
+	}
+	if !ctx.Piece.Abilities.Contains(AbilityGaleLift) {
+		return false, nil
+	}
+	return true, nil
+}

--- a/chessTest/internal/game/moves.go
+++ b/chessTest/internal/game/moves.go
@@ -263,6 +263,18 @@ func (e *Engine) instantiateAbilityHandlers(pc *Piece) (map[Ability][]AbilityHan
 		ensureHandlers()
 		handlers[AbilityScorch] = append(handlers[AbilityScorch], NewScorchHandler())
 	}
+	if pc.Abilities.Contains(AbilityTailwind) && len(handlers[AbilityTailwind]) == 0 {
+		ensureHandlers()
+		handlers[AbilityTailwind] = append(handlers[AbilityTailwind], NewTailwindHandler())
+	}
+	if pc.Abilities.Contains(AbilityRadiantVision) && len(handlers[AbilityRadiantVision]) == 0 {
+		ensureHandlers()
+		handlers[AbilityRadiantVision] = append(handlers[AbilityRadiantVision], NewRadiantVisionHandler())
+	}
+	if pc.Abilities.Contains(AbilityUmbralStep) && len(handlers[AbilityUmbralStep]) == 0 {
+		ensureHandlers()
+		handlers[AbilityUmbralStep] = append(handlers[AbilityUmbralStep], NewUmbralStepHandler())
+	}
 	if pc.Abilities.Contains(AbilityQuantumKill) && len(handlers[AbilityQuantumKill]) == 0 {
 		ensureHandlers()
 		handlers[AbilityQuantumKill] = append(handlers[AbilityQuantumKill], NewQuantumKillHandler())
@@ -270,6 +282,10 @@ func (e *Engine) instantiateAbilityHandlers(pc *Piece) (map[Ability][]AbilityHan
 	if pc.Abilities.Contains(AbilityChainKill) && len(handlers[AbilityChainKill]) == 0 {
 		ensureHandlers()
 		handlers[AbilityChainKill] = append(handlers[AbilityChainKill], NewChainKillHandler())
+	}
+	if pc.Abilities.Contains(AbilityGaleLift) && len(handlers[AbilityGaleLift]) == 0 {
+		ensureHandlers()
+		handlers[AbilityGaleLift] = append(handlers[AbilityGaleLift], NewGaleLiftHandler())
 	}
 	if pc.Abilities.Contains(AbilityPoisonousMeat) && len(handlers[AbilityPoisonousMeat]) == 0 {
 		ensureHandlers()
@@ -282,6 +298,10 @@ func (e *Engine) instantiateAbilityHandlers(pc *Piece) (map[Ability][]AbilityHan
 	if pc.Abilities.Contains(AbilityBastion) && len(handlers[AbilityBastion]) == 0 {
 		ensureHandlers()
 		handlers[AbilityBastion] = append(handlers[AbilityBastion], NewBastionHandler())
+	}
+	if pc.Abilities.Contains(AbilitySchrodingersLaugh) && len(handlers[AbilitySchrodingersLaugh]) == 0 {
+		ensureHandlers()
+		handlers[AbilitySchrodingersLaugh] = append(handlers[AbilitySchrodingersLaugh], NewSchrodingersLaughHandler())
 	}
 	if pc.Abilities.Contains(AbilityTemporalLock) && len(handlers[AbilityTemporalLock]) == 0 {
 		ensureHandlers()
@@ -1463,47 +1483,17 @@ func (e *Engine) endTurn(reason TurnEndReason) {
 // baseStepBudget calculates the total number of steps a piece gets for its turn without handler overrides.
 func (e *Engine) baseStepBudget(pc *Piece) int {
 	baseSteps := 1 // Every piece gets at least one step.
-	bonus := 0
-	element := elementOf(e, pc)
+	if pc == nil {
+		return baseSteps
+	}
 
-	// Elemental & Ability Bonuses/Penalties
-	if pc.Abilities.Contains(AbilityScorch) && element == ElementFire {
-		bonus++ // Scorch grants +1 step
-	}
-	if pc.Abilities.Contains(AbilityTailwind) && element == ElementAir {
-		bonus += 2 // Tailwind grants +2 steps
-		if pc.Abilities.Contains(AbilityTemporalLock) {
-			bonus-- // Temporal Lock slows Tailwind by 1
-		}
-	}
-	if pc.Abilities.Contains(AbilityRadiantVision) && element == ElementLight {
-		bonus++ // Radiant Vision grants +1 step
-		if pc.Abilities.Contains(AbilityMistShroud) {
-			bonus++ // Mist combo grants an additional step
-		}
-	}
-	if pc.Abilities.Contains(AbilityUmbralStep) && element == ElementShadow {
-		bonus += 2 // Umbral Step grants +2 steps
-		if pc.Abilities.Contains(AbilityRadiantVision) {
-			bonus-- // Radiant Vision dampens Umbral Step by 1
-		}
-	}
-	if pc.Abilities.Contains(AbilitySchrodingersLaugh) {
-		bonus += 2 // Schrodinger's Laugh grants +2 steps
-		if pc.Abilities.Contains(AbilitySideStep) {
-			bonus++ // Interaction bonus with Side Step
-		}
-	}
 	slowPenalty := e.temporalSlow[pc.Color.Index()]
 	if slowPenalty > 0 {
 		e.temporalSlow[pc.Color.Index()] = 0
+		baseSteps -= slowPenalty
 	}
 
-	totalSteps := baseSteps + bonus - slowPenalty
-	if totalSteps < 1 {
-		return 1 // A piece always gets at least 1 step.
-	}
-	return totalSteps
+	return baseSteps
 }
 
 func (e *Engine) calculateStepBudget(pc *Piece, handlers map[Ability][]AbilityHandler) (int, []string, error) {

--- a/chessTest/internal/game/moves_test.go
+++ b/chessTest/internal/game/moves_test.go
@@ -1053,7 +1053,16 @@ func TestResurrectionCaptureWindowExpires(t *testing.T) {
 	eng.placePiece(Black, Queen, blocked)
 	eng.board.turn = White
 
-	if steps := eng.baseStepBudget(eng.board.pieceAt[start]); steps < 3 {
+	mover := eng.board.pieceAt[start]
+	handlers, err := eng.instantiateAbilityHandlers(mover)
+	if err != nil {
+		t.Fatalf("instantiate handlers: %v", err)
+	}
+	steps, _, err := eng.calculateStepBudget(mover, handlers)
+	if err != nil {
+		t.Fatalf("calculate step budget: %v", err)
+	}
+	if steps < 3 {
 		t.Fatalf("expected at least 3 steps with buffs, got %d", steps)
 	}
 	if eng.abilities[Black.Index()].Contains(AbilityDoOver) {

--- a/chessTest/internal/game/piece_ops.go
+++ b/chessTest/internal/game/piece_ops.go
@@ -1,6 +1,10 @@
 package game
 
-import "battle_chess_poc/internal/shared"
+import (
+	"errors"
+
+	"battle_chess_poc/internal/shared"
+)
 
 func appendAbilityNote(dst *string, note string) {
 	if *dst == "" || *dst == "New game" || *dst == "Configuration locked - game started" {
@@ -230,6 +234,9 @@ func (e *Engine) canPhaseThrough(pc *Piece, from Square, to Square) bool {
 					}
 					allowed, err := handler.CanPhase(*ctx)
 					if err != nil {
+						if errors.Is(err, ErrPhaseDenied) {
+							return false
+						}
 						continue
 					}
 					if allowed {


### PR DESCRIPTION
## Summary
- add dedicated ability handlers for Tailwind, Radiant Vision, Umbral Step, Schrödinger's Laugh, Gale Lift, and extend existing handlers to manage step budget bonuses and penalties
- route Flood Wake and Bastion phasing vetoes plus Gale Lift/Umbral Step grants through the CanPhase hook and surface Temporal Lock slow via handler aggregation
- update tests to exercise the new step budget pipeline

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68db05380d0c83239bfae30941166bae