### PR TITLE
Refactor ability runtime storage

### DIFF
--- a/chessTest/internal/game/ability_resurrection_handler.go
+++ b/chessTest/internal/game/ability_resurrection_handler.go
@@ -93,6 +93,7 @@ func resetResurrectionState(move *MoveState) {
 	}
 	move.setAbilityFlag(AbilityResurrection, abilityFlagWindow, false)
 	move.setAbilityCounter(AbilityResurrection, abilityCounterResurrectionHold, 0)
+	move.setAbilityCounter(AbilityResurrection, abilityCounterResurrectionWindow, 0)
 }
 
 var (

--- a/chessTest/internal/game/engine.go
+++ b/chessTest/internal/game/engine.go
@@ -688,7 +688,7 @@ func (e *Engine) resurrectionWindowActive(pc *Piece) bool {
 	if e.currentMove == nil || e.currentMove.Piece != pc {
 		return false
 	}
-	if e.currentMove.abilityCounter(AbilityResurrection, abilityFlagWindow) > 0 {
+	if e.currentMove.abilityCounter(AbilityResurrection, abilityCounterResurrectionWindow) > 0 {
 		return true
 	}
 	return e.currentMove.abilityFlag(AbilityResurrection, abilityFlagWindow)

--- a/chessTest/internal/game/history.go
+++ b/chessTest/internal/game/history.go
@@ -159,14 +159,6 @@ func cloneMoveState(src *MoveState) *MoveState {
 	clone := *src
 	clone.Path = append([]Square(nil), src.Path...)
 	clone.Captures = append([]*Piece(nil), src.Captures...)
-	if len(src.AbilityData) > 0 {
-		clone.AbilityData = make(map[Ability]*AbilityRuntime, len(src.AbilityData))
-		for ability, runtime := range src.AbilityData {
-			clone.AbilityData[ability] = runtime.Clone()
-		}
-	} else {
-		clone.AbilityData = nil
-	}
 	return &clone
 }
 

--- a/chessTest/internal/game/move_continuation.go
+++ b/chessTest/internal/game/move_continuation.go
@@ -153,7 +153,7 @@ func (e *Engine) executeSpecialMovePlan(pc *Piece, from, to Square, plan Special
 	}
 	if plan.ResetResurrection && pc != nil && pc.Abilities.Contains(AbilityResurrection) {
 		e.currentMove.setAbilityFlag(AbilityResurrection, abilityFlagWindow, false)
-		e.currentMove.setAbilityCounter(AbilityResurrection, abilityFlagWindow, 0)
+		e.currentMove.setAbilityCounter(AbilityResurrection, abilityCounterResurrectionWindow, 0)
 	}
 
 	segmentStep := len(e.currentMove.Path) - 1

--- a/chessTest/internal/game/moves.go
+++ b/chessTest/internal/game/moves.go
@@ -249,7 +249,7 @@ func (e *Engine) continueMove(req MoveRequest) error {
 
 	if len(e.handlersForAbility(AbilityResurrection)) == 0 && pc.Abilities.Contains(AbilityResurrection) && e.currentMove.abilityFlag(AbilityResurrection, abilityFlagWindow) {
 		e.currentMove.setAbilityFlag(AbilityResurrection, abilityFlagWindow, false)
-		e.currentMove.setAbilityCounter(AbilityResurrection, abilityFlagWindow, 0)
+		e.currentMove.setAbilityCounter(AbilityResurrection, abilityCounterResurrectionWindow, 0)
 	}
 
 	delta := e.pushHistory()

--- a/chessTest/internal/game/moves_test.go
+++ b/chessTest/internal/game/moves_test.go
@@ -13,6 +13,37 @@ func init() {
 	})
 }
 
+func TestMoveStateAbilityRuntimeZeroAlloc(t *testing.T) {
+	pc := &Piece{Abilities: AbilityList{AbilityResurrection, AbilityMistShroud}}
+	move := initializeMoveState(pc, 0, 3, nil, Pawn, false)
+
+	run := func() {
+		move.setAbilityFlag(AbilityResurrection, abilityFlagWindow, true)
+		_ = move.abilityFlag(AbilityResurrection, abilityFlagWindow)
+		move.setAbilityFlag(AbilityResurrection, abilityFlagWindow, false)
+
+		move.setAbilityFlag(AbilityNone, abilityFlagCaptureExtra, true)
+		_ = move.abilityFlag(AbilityNone, abilityFlagCaptureExtra)
+		move.setAbilityFlag(AbilityNone, abilityFlagCaptureExtra, false)
+
+		move.setAbilityCounter(AbilityResurrection, abilityCounterResurrectionHold, 1)
+		move.addAbilityCounter(AbilityResurrection, abilityCounterResurrectionHold, -1)
+		_ = move.abilityCounter(AbilityResurrection, abilityCounterResurrectionHold)
+
+		move.setAbilityCounter(AbilityNone, abilityCounterCaptures, 2)
+		_ = move.captureCount()
+		move.setAbilityCounter(AbilityNone, abilityCounterCaptures, 0)
+
+		move.setAbilityCounter(AbilityResurrection, abilityCounterResurrectionWindow, 1)
+		_ = move.abilityCounter(AbilityResurrection, abilityCounterResurrectionWindow)
+		move.setAbilityCounter(AbilityResurrection, abilityCounterResurrectionWindow, 0)
+	}
+
+	if allocs := testing.AllocsPerRun(100, run); allocs != 0 {
+		t.Fatalf("expected zero allocations during ability runtime operations, got %f", allocs)
+	}
+}
+
 func TestSliderOpeningMovesDoNotPanic(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/chessTest/internal/game/types.go
+++ b/chessTest/internal/game/types.go
@@ -127,6 +127,8 @@ const (
 	AbilitySchrodingersLaugh
 )
 
+const AbilityCount = int(AbilitySchrodingersLaugh) + 1
+
 type AbilityList []Ability
 
 func (al AbilityList) Contains(target Ability) bool {


### PR DESCRIPTION
## Summary
- replace the map-backed ability runtime with fixed-size arrays and typed indices for flags and counters
- store move ability state in dense tables keyed by ability ordinals and update engine paths accordingly
- update cloning logic and add a regression test to enforce zero-allocation ability runtime operations

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68db16cff3a88323aa35e3260a858622