### PR TITLE
Refactor ability handler storage with bitsets

### DIFF
--- a/chessTest/internal/game/ability_capture_handlers.go
+++ b/chessTest/internal/game/ability_capture_handlers.go
@@ -1,3 +1,4 @@
+// path: chessTest/internal/game/ability_capture_handlers.go
 package game
 
 import "fmt"
@@ -46,7 +47,7 @@ func (scorchHandler) StepBudgetModifier(ctx StepBudgetContext) (StepBudgetDelta,
 		return StepBudgetDelta{}, nil
 	}
 	pc := ctx.Piece
-	if !pc.Abilities.Contains(AbilityScorch) {
+	if !pc.HasAbility(AbilityScorch) {
 		return StepBudgetDelta{}, nil
 	}
 	if elementOf(ctx.Engine, pc) != ElementFire {
@@ -139,7 +140,7 @@ func (poisonousMeatHandler) ResolveCapture(ctx CaptureContext) (CaptureOutcome, 
 		return CaptureOutcome{}, nil
 	}
 	attacker := ctx.Attacker
-	if !attacker.Abilities.Contains(AbilityPoisonousMeat) {
+	if !attacker.HasAbility(AbilityPoisonousMeat) {
 		return CaptureOutcome{}, nil
 	}
 	outcome := CaptureOutcome{ForceTurnEnd: true}
@@ -163,12 +164,12 @@ func (overloadHandler) ResolveCapture(ctx CaptureContext) (CaptureOutcome, error
 		return CaptureOutcome{}, nil
 	}
 	attacker := ctx.Attacker
-	if !attacker.Abilities.Contains(AbilityOverload) {
+	if !attacker.HasAbility(AbilityOverload) {
 		return CaptureOutcome{}, nil
 	}
 	element := elementOf(ctx.Engine, attacker)
 	outcome := CaptureOutcome{}
-	if attacker.Abilities.Contains(AbilityStalwart) && element == ElementLightning && ctx.Move.RemainingSteps > 0 {
+	if attacker.HasAbility(AbilityStalwart) && element == ElementLightning && ctx.Move.RemainingSteps > 0 {
 		outcome.StepAdjustment = -1
 		appendAbilityNote(&ctx.Engine.board.lastNote, "Overload + Stalwart costs 1 step")
 	}
@@ -195,7 +196,7 @@ func (bastionHandler) ResolveCapture(ctx CaptureContext) (CaptureOutcome, error)
 		return CaptureOutcome{}, nil
 	}
 	attacker := ctx.Attacker
-	if !attacker.Abilities.Contains(AbilityBastion) {
+	if !attacker.HasAbility(AbilityBastion) {
 		return CaptureOutcome{}, nil
 	}
 	if elementOf(ctx.Engine, attacker) != ElementEarth {
@@ -217,7 +218,7 @@ func (temporalLockHandler) ResolveTurnEnd(ctx TurnEndContext) (TurnEndOutcome, e
 		return TurnEndOutcome{}, nil
 	}
 	pc := ctx.Move.Piece
-	if !pc.Abilities.Contains(AbilityTemporalLock) {
+	if !pc.HasAbility(AbilityTemporalLock) {
 		return TurnEndOutcome{}, nil
 	}
 	slow := 1

--- a/chessTest/internal/game/ability_fallbacks.go
+++ b/chessTest/internal/game/ability_fallbacks.go
@@ -1,3 +1,4 @@
+// path: chessTest/internal/game/ability_fallbacks.go
 package game
 
 // abilityHandlerBase provides default implementations for AbilityHandler
@@ -59,7 +60,7 @@ func (blazeRushFallbackHandler) PrepareSegment(ctx *SegmentPreparationContext) e
 		return nil
 	}
 	pc := ctx.Move.Piece
-	if pc == nil || !pc.Abilities.Contains(AbilityBlazeRush) {
+	if pc == nil || !pc.HasAbility(AbilityBlazeRush) {
 		return nil
 	}
 	if !ctx.Engine.isBlazeRushDash(pc, ctx.From, ctx.To, ctx.Segment.Capture) {
@@ -112,7 +113,7 @@ func (floodWakeFallbackHandler) PrepareSegment(ctx *SegmentPreparationContext) e
 		return nil
 	}
 	pc := ctx.Move.Piece
-	if pc == nil || !pc.Abilities.Contains(AbilityFloodWake) {
+	if pc == nil || !pc.HasAbility(AbilityFloodWake) {
 		return nil
 	}
 	if !ctx.Engine.isFloodWakePushAvailable(pc, ctx.From, ctx.To, ctx.Segment.Capture) {
@@ -162,7 +163,7 @@ func (mistShroudFallbackHandler) PrepareSegment(ctx *SegmentPreparationContext) 
 	}
 	move := ctx.Move
 	pc := move.Piece
-	if pc == nil || !pc.Abilities.Contains(AbilityMistShroud) {
+	if pc == nil || !pc.HasAbility(AbilityMistShroud) {
 		return nil
 	}
 	if move.abilityCounter(AbilityMistShroud, abilityCounterFree) != 0 {
@@ -181,7 +182,7 @@ func (mistShroudFallbackHandler) OnDirectionChange(ctx DirectionChangeContext) b
 	if ctx.Engine == nil || ctx.Move == nil || ctx.Piece == nil {
 		return false
 	}
-	if !ctx.Piece.Abilities.Contains(AbilityMistShroud) {
+	if !ctx.Piece.HasAbility(AbilityMistShroud) {
 		return false
 	}
 	if ctx.Move.abilityCounter(AbilityMistShroud, abilityCounterFree) != 0 {
@@ -207,7 +208,7 @@ func (sideStepFallbackHandler) PlanSpecialMove(ctx *SpecialMoveContext) (Special
 		return SpecialMovePlan{}, false, nil
 	}
 	pc := ctx.Piece
-	if !pc.Abilities.Contains(AbilitySideStep) {
+	if !pc.HasAbility(AbilitySideStep) {
 		return SpecialMovePlan{}, false, nil
 	}
 	if ctx.Move.abilityUsed(AbilitySideStep) || ctx.Move.RemainingSteps <= 0 {
@@ -247,7 +248,7 @@ func (quantumStepFallbackHandler) PlanSpecialMove(ctx *SpecialMoveContext) (Spec
 		return SpecialMovePlan{}, false, nil
 	}
 	pc := ctx.Piece
-	if !pc.Abilities.Contains(AbilityQuantumStep) {
+	if !pc.HasAbility(AbilityQuantumStep) {
 		return SpecialMovePlan{}, false, nil
 	}
 	if ctx.Move.abilityUsed(AbilityQuantumStep) || ctx.Move.RemainingSteps <= 0 {
@@ -290,3 +291,25 @@ var (
 	_ SpecialMoveHandler        = sideStepFallbackHandler{}
 	_ SpecialMoveHandler        = quantumStepFallbackHandler{}
 )
+
+func init() {
+	registerAbilityFallback(AbilityBlazeRush, newBlazeRushFallbackHandler())
+	registerAbilityFallback(AbilityFloodWake, newFloodWakeFallbackHandler())
+	registerAbilityFallback(AbilitySideStep, newSideStepFallbackHandler())
+	registerAbilityFallback(AbilityQuantumStep, newQuantumStepFallbackHandler())
+	registerAbilityFallback(AbilityMistShroud, newMistShroudFallbackHandler())
+	registerAbilityFallback(AbilityDoubleKill, NewDoubleKillHandler())
+	registerAbilityFallback(AbilityScorch, NewScorchHandler())
+	registerAbilityFallback(AbilityTailwind, NewTailwindHandler())
+	registerAbilityFallback(AbilityRadiantVision, NewRadiantVisionHandler())
+	registerAbilityFallback(AbilityUmbralStep, NewUmbralStepHandler())
+	registerAbilityFallback(AbilityQuantumKill, NewQuantumKillHandler())
+	registerAbilityFallback(AbilityChainKill, NewChainKillHandler())
+	registerAbilityFallback(AbilityGaleLift, NewGaleLiftHandler())
+	registerAbilityFallback(AbilityPoisonousMeat, NewPoisonousMeatHandler())
+	registerAbilityFallback(AbilityOverload, NewOverloadHandler())
+	registerAbilityFallback(AbilityBastion, NewBastionHandler())
+	registerAbilityFallback(AbilitySchrodingersLaugh, NewSchrodingersLaughHandler())
+	registerAbilityFallback(AbilityTemporalLock, NewTemporalLockHandler())
+	registerAbilityFallback(AbilityResurrection, NewResurrectionHandler())
+}

--- a/chessTest/internal/game/ability_registry.go
+++ b/chessTest/internal/game/ability_registry.go
@@ -4,7 +4,8 @@ package game
 import "errors"
 
 var (
-	abilityFactory func(Ability) (AbilityHandler, error)
+	abilityFactory   func(Ability) (AbilityHandler, error)
+	fallbackHandlers [AbilityCount][]AbilityHandler
 
 	// ErrAbilityFactoryNotConfigured indicates no resolver has been registered.
 	ErrAbilityFactoryNotConfigured = errors.New("game: ability factory not configured")
@@ -22,4 +23,23 @@ func resolveAbilityHandler(id Ability) (AbilityHandler, error) {
 		return nil, ErrAbilityFactoryNotConfigured
 	}
 	return abilityFactory(id)
+}
+
+func registerAbilityFallback(id Ability, handler AbilityHandler) {
+	if handler == nil {
+		return
+	}
+	idx := abilityIndex(id)
+	if idx < 0 {
+		return
+	}
+	fallbackHandlers[idx] = append(fallbackHandlers[idx], handler)
+}
+
+func fallbackHandlersFor(id Ability) []AbilityHandler {
+	idx := abilityIndex(id)
+	if idx < 0 {
+		return nil
+	}
+	return fallbackHandlers[idx]
 }

--- a/chessTest/internal/game/ability_step_budget_handlers.go
+++ b/chessTest/internal/game/ability_step_budget_handlers.go
@@ -1,3 +1,4 @@
+// path: chessTest/internal/game/ability_step_budget_handlers.go
 package game
 
 // NewTailwindHandler constructs the default Tailwind ability handler.
@@ -12,7 +13,7 @@ func (tailwindHandler) StepBudgetModifier(ctx StepBudgetContext) (StepBudgetDelt
 		return StepBudgetDelta{}, nil
 	}
 	pc := ctx.Piece
-	if !pc.Abilities.Contains(AbilityTailwind) {
+	if !pc.HasAbility(AbilityTailwind) {
 		return StepBudgetDelta{}, nil
 	}
 	if elementOf(ctx.Engine, pc) != ElementAir {
@@ -20,7 +21,7 @@ func (tailwindHandler) StepBudgetModifier(ctx StepBudgetContext) (StepBudgetDelt
 	}
 
 	delta := StepBudgetDelta{AddSteps: 2, Notes: []string{"Tailwind grants +2 steps"}}
-	if pc.Abilities.Contains(AbilityTemporalLock) {
+	if pc.HasAbility(AbilityTemporalLock) {
 		delta.AddSteps--
 		delta.Notes = append(delta.Notes, "Temporal Lock dampens Tailwind (-1 step)")
 	}
@@ -39,7 +40,7 @@ func (radiantVisionHandler) StepBudgetModifier(ctx StepBudgetContext) (StepBudge
 		return StepBudgetDelta{}, nil
 	}
 	pc := ctx.Piece
-	if !pc.Abilities.Contains(AbilityRadiantVision) {
+	if !pc.HasAbility(AbilityRadiantVision) {
 		return StepBudgetDelta{}, nil
 	}
 	if elementOf(ctx.Engine, pc) != ElementLight {
@@ -47,7 +48,7 @@ func (radiantVisionHandler) StepBudgetModifier(ctx StepBudgetContext) (StepBudge
 	}
 
 	delta := StepBudgetDelta{AddSteps: 1, Notes: []string{"Radiant Vision grants +1 step"}}
-	if pc.Abilities.Contains(AbilityMistShroud) {
+	if pc.HasAbility(AbilityMistShroud) {
 		delta.AddSteps++
 		delta.Notes = append(delta.Notes, "Mist Shroud combo adds +1 step")
 	}
@@ -66,7 +67,7 @@ func (umbralStepHandler) StepBudgetModifier(ctx StepBudgetContext) (StepBudgetDe
 		return StepBudgetDelta{}, nil
 	}
 	pc := ctx.Piece
-	if !pc.Abilities.Contains(AbilityUmbralStep) {
+	if !pc.HasAbility(AbilityUmbralStep) {
 		return StepBudgetDelta{}, nil
 	}
 	if elementOf(ctx.Engine, pc) != ElementShadow {
@@ -74,7 +75,7 @@ func (umbralStepHandler) StepBudgetModifier(ctx StepBudgetContext) (StepBudgetDe
 	}
 
 	delta := StepBudgetDelta{AddSteps: 2, Notes: []string{"Umbral Step grants +2 steps"}}
-	if pc.Abilities.Contains(AbilityRadiantVision) {
+	if pc.HasAbility(AbilityRadiantVision) {
 		delta.AddSteps--
 		delta.Notes = append(delta.Notes, "Radiant Vision reduces Umbral Step by 1")
 	}
@@ -85,7 +86,7 @@ func (umbralStepHandler) CanPhase(ctx PhaseContext) (bool, error) {
 	if ctx.Piece == nil {
 		return false, nil
 	}
-	if !ctx.Piece.Abilities.Contains(AbilityUmbralStep) {
+	if !ctx.Piece.HasAbility(AbilityUmbralStep) {
 		return false, nil
 	}
 	return true, nil
@@ -103,12 +104,12 @@ func (schrodingersLaughHandler) StepBudgetModifier(ctx StepBudgetContext) (StepB
 		return StepBudgetDelta{}, nil
 	}
 	pc := ctx.Piece
-	if !pc.Abilities.Contains(AbilitySchrodingersLaugh) {
+	if !pc.HasAbility(AbilitySchrodingersLaugh) {
 		return StepBudgetDelta{}, nil
 	}
 
 	delta := StepBudgetDelta{AddSteps: 2, Notes: []string{"Schrödinger's Laugh grants +2 steps"}}
-	if pc.Abilities.Contains(AbilitySideStep) {
+	if pc.HasAbility(AbilitySideStep) {
 		delta.AddSteps++
 		delta.Notes = append(delta.Notes, "Side Step combo adds +1 step")
 	}
@@ -126,7 +127,7 @@ func (galeLiftHandler) CanPhase(ctx PhaseContext) (bool, error) {
 	if ctx.Piece == nil {
 		return false, nil
 	}
-	if !ctx.Piece.Abilities.Contains(AbilityGaleLift) {
+	if !ctx.Piece.HasAbility(AbilityGaleLift) {
 		return false, nil
 	}
 	return true, nil

--- a/chessTest/internal/game/history.go
+++ b/chessTest/internal/game/history.go
@@ -1,3 +1,4 @@
+// path: chessTest/internal/game/history.go
 package game
 
 // historyDelta captures the minimal state needed to undo a single move segment.
@@ -105,6 +106,7 @@ func (d *historyDelta) apply(e *Engine) {
 		}
 		restored := entry.snapshot.pieceData
 		restored.Abilities = restored.Abilities.Clone()
+		restored.AbilityMask = restored.Abilities.Set()
 		*entry.piece = restored
 		e.board.pieceAt[entry.square] = entry.piece
 		e.board.pieces[entry.piece.Color][entry.piece.Type] = e.board.pieces[entry.piece.Color][entry.piece.Type].Add(entry.square)
@@ -149,6 +151,7 @@ func (d *historyDelta) apply(e *Engine) {
 func clonePieceState(pc *Piece) Piece {
 	clone := *pc
 	clone.Abilities = pc.Abilities.Clone()
+	clone.AbilityMask = clone.Abilities.Set()
 	return clone
 }
 

--- a/chessTest/internal/game/move_continuation.go
+++ b/chessTest/internal/game/move_continuation.go
@@ -151,10 +151,10 @@ func (e *Engine) executeSpecialMovePlan(pc *Piece, from, to Square, plan Special
 	if plan.MarkAbilityUsed && plan.Ability != AbilityNone {
 		e.currentMove.markAbilityUsed(plan.Ability)
 	}
-	if plan.ResetResurrection && pc != nil && pc.Abilities.Contains(AbilityResurrection) {
-		e.currentMove.setAbilityFlag(AbilityResurrection, abilityFlagWindow, false)
-		e.currentMove.setAbilityCounter(AbilityResurrection, abilityCounterResurrectionWindow, 0)
-	}
+        if plan.ResetResurrection && pc != nil && pc.HasAbility(AbilityResurrection) {
+                e.currentMove.setAbilityFlag(AbilityResurrection, abilityFlagWindow, false)
+                e.currentMove.setAbilityCounter(AbilityResurrection, abilityCounterResurrectionWindow, 0)
+        }
 
 	segmentStep := len(e.currentMove.Path) - 1
 	if segmentStep < 0 {
@@ -426,9 +426,9 @@ func (e *Engine) hasFloodWakePushOption(pc *Piece) bool {
 }
 
 func (e *Engine) blazeRushContinuationAvailable(pc *Piece) bool {
-	if pc == nil || !pc.Abilities.Contains(AbilityBlazeRush) {
-		return false
-	}
+        if pc == nil || !pc.HasAbility(AbilityBlazeRush) {
+                return false
+        }
 	if e.currentMove == nil || e.currentMove.abilityUsed(AbilityBlazeRush) || e.currentMove.LastSegmentCaptured {
 		return false
 	}
@@ -455,9 +455,9 @@ func (e *Engine) blazeRushContinuationAvailable(pc *Piece) bool {
 }
 
 func (e *Engine) floodWakeContinuationAvailable(pc *Piece) bool {
-	if pc == nil || !pc.Abilities.Contains(AbilityFloodWake) {
-		return false
-	}
+        if pc == nil || !pc.HasAbility(AbilityFloodWake) {
+                return false
+        }
 	if e.currentMove == nil || e.currentMove.abilityUsed(AbilityFloodWake) {
 		return false
 	}
@@ -520,21 +520,21 @@ func maxInt(a, b int) int {
 }
 
 func (e *Engine) checkPostMoveAbilities(pc *Piece) {
-	if pc.Abilities.Contains(AbilitySideStep) && !e.currentMove.abilityUsed(AbilitySideStep) && e.currentMove.RemainingSteps > 0 {
-		appendAbilityNote(&e.board.lastNote, "Side Step available (costs 1 step)")
-	}
-	if pc.Abilities.Contains(AbilityQuantumStep) && !e.currentMove.abilityUsed(AbilityQuantumStep) && e.currentMove.RemainingSteps > 0 {
-		appendAbilityNote(&e.board.lastNote, "Quantum Step available (costs 1 step)")
-	}
+        if pc.HasAbility(AbilitySideStep) && !e.currentMove.abilityUsed(AbilitySideStep) && e.currentMove.RemainingSteps > 0 {
+                appendAbilityNote(&e.board.lastNote, "Side Step available (costs 1 step)")
+        }
+        if pc.HasAbility(AbilityQuantumStep) && !e.currentMove.abilityUsed(AbilityQuantumStep) && e.currentMove.RemainingSteps > 0 {
+                appendAbilityNote(&e.board.lastNote, "Quantum Step available (costs 1 step)")
+        }
 }
 
 func (e *Engine) isFloodWakePushAvailable(pc *Piece, from, to Square, target *Piece) bool {
-	if pc == nil || target != nil {
-		return false
-	}
-	if !pc.Abilities.Contains(AbilityFloodWake) {
-		return false
-	}
+        if pc == nil || target != nil {
+                return false
+        }
+        if !pc.HasAbility(AbilityFloodWake) {
+                return false
+        }
 	if elementOf(e, pc) != ElementWater {
 		return false
 	}
@@ -550,12 +550,12 @@ func (e *Engine) isFloodWakePushAvailable(pc *Piece, from, to Square, target *Pi
 }
 
 func (e *Engine) isBlazeRushDash(pc *Piece, from, to Square, target *Piece) bool {
-	if pc == nil || target != nil {
-		return false
-	}
-	if !pc.Abilities.Contains(AbilityBlazeRush) {
-		return false
-	}
+        if pc == nil || target != nil {
+                return false
+        }
+        if !pc.HasAbility(AbilityBlazeRush) {
+                return false
+        }
 	if !e.isSlider(pc.Type) {
 		return false
 	}

--- a/chessTest/internal/game/move_legality.go
+++ b/chessTest/internal/game/move_legality.go
@@ -19,17 +19,17 @@ func (e *Engine) pathIsPassable(pc *Piece, from, to Square) bool {
 		if !canPhase {
 			return false
 		}
-		if occupant.Abilities.Contains(AbilityIndomitable) || occupant.Abilities.Contains(AbilityStalwart) {
-			return false
-		}
+                if occupant.HasAbility(AbilityIndomitable) || occupant.HasAbility(AbilityStalwart) {
+                        return false
+                }
 	}
 	return true
 }
 
 func isScatterShotCapture(pc *Piece, from, to Square) bool {
-	if pc == nil || !pc.Abilities.Contains(AbilityScatterShot) {
-		return false
-	}
+        if pc == nil || !pc.HasAbility(AbilityScatterShot) {
+                return false
+        }
 	if from.Rank() != to.Rank() {
 		return false
 	}
@@ -47,15 +47,15 @@ func (e *Engine) canDirectCapture(attacker, defender *Piece, from, to Square) bo
 	if attacker == nil {
 		return false
 	}
-	if defender.Abilities.Contains(AbilityStalwart) && rankOf(attacker.Type) < rankOf(defender.Type) {
-		return false
-	}
-	if defender.Abilities.Contains(AbilityBelligerent) && rankOf(attacker.Type) > rankOf(defender.Type) {
-		return false
-	}
-	if isScatterShotCapture(attacker, from, to) && defender.Abilities.Contains(AbilityIndomitable) {
-		return false
-	}
+        if defender.HasAbility(AbilityStalwart) && rankOf(attacker.Type) < rankOf(defender.Type) {
+                return false
+        }
+        if defender.HasAbility(AbilityBelligerent) && rankOf(attacker.Type) > rankOf(defender.Type) {
+                return false
+        }
+        if isScatterShotCapture(attacker, from, to) && defender.HasAbility(AbilityIndomitable) {
+                return false
+        }
 	return true
 }
 

--- a/chessTest/internal/game/move_state.go
+++ b/chessTest/internal/game/move_state.go
@@ -13,10 +13,10 @@ type MoveState struct {
 	LastSegmentCaptured bool
 	Promotion           PieceType
 	PromotionSet        bool
-	Handlers            map[Ability][]AbilityHandler
+	Handlers            *abilityHandlerTable
 }
 
-func initializeMoveState(pc *Piece, start Square, remaining int, handlers map[Ability][]AbilityHandler, promotion PieceType, promotionSet bool) *MoveState {
+func initializeMoveState(pc *Piece, start Square, remaining int, handlers *abilityHandlerTable, promotion PieceType, promotionSet bool) *MoveState {
 	abilities := AbilityList(nil)
 	if pc != nil {
 		abilities = pc.Abilities
@@ -108,8 +108,8 @@ func (ms *MoveState) addAbilityCounter(id Ability, key abilityCounterIndex, delt
 }
 
 func (ms *MoveState) handlersFor(id Ability) []AbilityHandler {
-	if ms == nil || len(ms.Handlers) == 0 {
+	if ms == nil || ms.Handlers == nil {
 		return nil
 	}
-	return ms.Handlers[id]
+	return ms.Handlers.handlersFor(id)
 }

--- a/chessTest/internal/game/moves.go
+++ b/chessTest/internal/game/moves.go
@@ -20,6 +20,11 @@ func (e *Engine) startNewMove(req MoveRequest) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if e.currentMove == nil {
+			e.resetAbilityHandlers()
+		}
+	}()
 
 	target := e.board.pieceAt[to]
 	if target != nil && target.Color == pc.Color {
@@ -174,6 +179,12 @@ func (e *Engine) continueMove(req MoveRequest) error {
 		return errors.New("no active move to continue")
 	}
 
+	defer func() {
+		if e.currentMove == nil {
+			e.resetAbilityHandlers()
+		}
+	}()
+
 	pc := e.currentMove.Piece
 	from, to := req.From, req.To
 	if from != pc.Square {
@@ -247,7 +258,7 @@ func (e *Engine) continueMove(req MoveRequest) error {
 		return fmt.Errorf("insufficient steps: %d needed, %d remaining", stepsNeeded, e.currentMove.RemainingSteps)
 	}
 
-	if len(e.handlersForAbility(AbilityResurrection)) == 0 && pc.Abilities.Contains(AbilityResurrection) && e.currentMove.abilityFlag(AbilityResurrection, abilityFlagWindow) {
+	if len(e.handlersForAbility(AbilityResurrection)) == 0 && pc.HasAbility(AbilityResurrection) && e.currentMove.abilityFlag(AbilityResurrection, abilityFlagWindow) {
 		e.currentMove.setAbilityFlag(AbilityResurrection, abilityFlagWindow, false)
 		e.currentMove.setAbilityCounter(AbilityResurrection, abilityCounterResurrectionWindow, 0)
 	}

--- a/chessTest/internal/game/moves_test.go
+++ b/chessTest/internal/game/moves_test.go
@@ -1,3 +1,4 @@
+// path: chessTest/internal/game/moves_test.go
 package game
 
 import (
@@ -14,7 +15,8 @@ func init() {
 }
 
 func TestMoveStateAbilityRuntimeZeroAlloc(t *testing.T) {
-	pc := &Piece{Abilities: AbilityList{AbilityResurrection, AbilityMistShroud}}
+	pc := &Piece{}
+	pc.SetAbilities(AbilityList{AbilityResurrection, AbilityMistShroud})
 	move := initializeMoveState(pc, 0, 3, nil, Pawn, false)
 
 	run := func() {
@@ -598,7 +600,7 @@ func TestHistoryDeltaMultiSegmentDoOverRestoresState(t *testing.T) {
 		t.Fatalf("expected %s to be empty after rewind", nudgeSq)
 	}
 
-	if victim.Abilities.Contains(AbilityDoOver) {
+	if victim.HasAbility(AbilityDoOver) {
 		t.Fatalf("expected DoOver ability to be consumed")
 	}
 	if !eng.pendingDoOver[victim.ID] {
@@ -1096,12 +1098,12 @@ func TestResurrectionCaptureWindowExpires(t *testing.T) {
 	if steps < 3 {
 		t.Fatalf("expected at least 3 steps with buffs, got %d", steps)
 	}
-	if eng.abilities[Black.Index()].Contains(AbilityDoOver) {
+	if eng.sideHasAbility(Black, AbilityDoOver) {
 		t.Fatalf("black side unexpectedly configured with Do-Over")
 	}
 	if pc := eng.board.pieceAt[firstCapture]; pc == nil {
 		t.Fatalf("expected black piece at %s", firstCapture)
-	} else if pc.Abilities.Contains(AbilityDoOver) {
+	} else if pc.HasAbility(AbilityDoOver) {
 		t.Fatalf("test setup gave victim Do-Over unexpectedly")
 	}
 

--- a/chessTest/internal/game/types.go
+++ b/chessTest/internal/game/types.go
@@ -131,13 +131,61 @@ const AbilityCount = int(AbilitySchrodingersLaugh) + 1
 
 type AbilityList []Ability
 
-func (al AbilityList) Contains(target Ability) bool {
-	for _, ability := range al {
-		if ability == target {
-			return true
-		}
+type AbilitySet uint64
+
+func abilityIndex(id Ability) int {
+	idx := int(id)
+	if idx < 0 || idx >= AbilityCount {
+		return -1
 	}
-	return false
+	return idx
+}
+
+func abilityBit(id Ability) AbilitySet {
+	idx := abilityIndex(id)
+	if idx < 0 {
+		return 0
+	}
+	return AbilitySet(1) << uint(idx)
+}
+
+func (s AbilitySet) With(id Ability) AbilitySet { return s | abilityBit(id) }
+
+func (s AbilitySet) Without(id Ability) AbilitySet { return s &^ abilityBit(id) }
+
+func (s AbilitySet) Has(id Ability) bool { return s&abilityBit(id) != 0 }
+
+func (s AbilitySet) Empty() bool { return s == 0 }
+
+func NewAbilitySet(ids ...Ability) AbilitySet {
+	var set AbilitySet
+	for _, id := range ids {
+		if id == AbilityNone {
+			continue
+		}
+		set |= abilityBit(id)
+	}
+	return set
+}
+
+func AbilitySetFromList(list AbilityList) AbilitySet {
+	if len(list) == 0 {
+		return 0
+	}
+	var set AbilitySet
+	for _, id := range list {
+		if id == AbilityNone {
+			continue
+		}
+		set |= abilityBit(id)
+	}
+	return set
+}
+
+func (al AbilityList) Set() AbilitySet { return AbilitySetFromList(al) }
+
+func (al AbilityList) Contains(target Ability) bool {
+	return al.Set().Has(target)
 }
 
 func (al AbilityList) Clone() AbilityList {


### PR DESCRIPTION
## Summary
- Add an AbilitySet bitmask and helper methods so pieces and sides maintain slice order alongside constant-time membership checks.
- Replace ability handler maps with pooled fixed-size tables and centralized fallback registration to reuse handlers deterministically.
- Update engine logic and tests to consume the new structures, ensuring ability cleanup paths reset pooled tables.

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68db18c89e14832396af9d02222313c6