### PR TITLE
Integrate engine with HTTP server

### DIFF
--- a/chessTest/cmd/server/main.go
+++ b/chessTest/cmd/server/main.go
@@ -10,9 +10,8 @@ import (
 	"os"
 	"strings"
 
-	// Adjust these imports to your actual module paths if different.
-	"battle_chess_poc/internal/game"  // your engine: NewEngine(), SetSideConfig(...), etc.
-	"battle_chess_poc/internal/httpx" // your HTTP server wrapper exposing Listen(engine) or similar
+	"battle_chess_poc/internal/game"
+	"battle_chess_poc/internal/httpx"
 )
 
 func main() {
@@ -50,7 +49,10 @@ func main() {
 		log.Printf("No preconfig. Both players must select Ability/Element before the match starts.")
 	}
 
-	srv := httpx.NewServer(eng)
+	srv, err := httpx.NewServer(eng)
+	if err != nil {
+		log.Fatalf("http init: %v", err)
+	}
 	log.Printf("HTTP listening on %s", *addr)
 	if err := srv.Listen(*addr); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
## Summary
- wire the CLI entrypoint to instantiate the engine, apply optional preconfiguration, and start the HTTP server
- rebuild the HTTP façade to lock the engine, validate payloads with game parsers, and serve the UI template with cached option lists
- harden JSON handling with bounded bodies, strict decoding, and timeouts on the listener

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68db2591118c8323927ad56651e585f5