### PR TITLE
Protect index render with engine lock

### DIFF
--- a/chessTest/internal/httpx/server.go
+++ b/chessTest/internal/httpx/server.go
@@ -68,12 +68,15 @@ func (s *Server) routes() http.Handler {
 
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	// Build initial payload embedding current engine state and option lists.
+	s.engineMu.Lock()
+	state := s.engine.State()
+	s.engineMu.Unlock()
 	init := struct {
 		State     game.BoardState `json:"state"`
 		Abilities []string        `json:"abilities"`
 		Elements  []string        `json:"elements"`
 	}{
-		State:     s.engine.State(),
+		State:     state,
 		Abilities: s.abilities,
 		Elements:  s.elements,
 	}


### PR DESCRIPTION
## Summary
- guard the engine state retrieval in the index handler with the existing mutex
- keep the critical section minimal by copying the state before rendering the template

## Testing
- `go test ./...` *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68db2bbb3b408323a48e334c92126b00