### PR TITLE
Handle Do-Over responses as soft warnings

### DIFF
--- a/chessTest/internal/httpx/server.go
+++ b/chessTest/internal/httpx/server.go
@@ -252,10 +252,19 @@ func (s *Server) handleMove(w http.ResponseWriter, r *http.Request) {
 	s.engineMu.Unlock()
 
 	if err != nil {
+		if errors.Is(err, game.ErrDoOverActivated) || errors.Is(err, game.ErrCaptureBlocked) {
+			writeJSON(w, struct {
+				State   game.BoardState `json:"state"`
+				Message string          `json:"message"`
+			}{State: state, Message: err.Error()})
+			return
+		}
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	writeJSON(w, map[string]any{"state": state})
+	writeJSON(w, struct {
+		State game.BoardState `json:"state"`
+	}{State: state})
 }
 
 // ---- API: config ----

--- a/chessTest/internal/httpx/server_test.go
+++ b/chessTest/internal/httpx/server_test.go
@@ -1,0 +1,67 @@
+// path: chessTest/internal/httpx/server_test.go
+package httpx
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"battle_chess_poc/internal/game"
+)
+
+func TestHandleMoveDoOverReturnsState(t *testing.T) {
+	eng := game.NewEngine()
+	if err := eng.SetSideConfig(game.White, game.AbilityList{game.AbilityDoOver}, game.ElementLight); err != nil {
+		t.Fatalf("configure white: %v", err)
+	}
+	if err := eng.SetSideConfig(game.Black, game.AbilityList{game.AbilityDoOver}, game.ElementShadow); err != nil {
+		t.Fatalf("configure black: %v", err)
+	}
+
+	e2, _ := game.CoordToSquare("e2")
+	e4, _ := game.CoordToSquare("e4")
+	if err := eng.Move(game.MoveRequest{From: e2, To: e4, Dir: game.DirNone}); err != nil {
+		t.Fatalf("white opening move: %v", err)
+	}
+	d7, _ := game.CoordToSquare("d7")
+	d5, _ := game.CoordToSquare("d5")
+	if err := eng.Move(game.MoveRequest{From: d7, To: d5, Dir: game.DirNone}); err != nil {
+		t.Fatalf("black reply move: %v", err)
+	}
+
+	srv := &Server{engine: eng}
+
+	reqBody := `{"from":"e4","to":"d5","dir":""}`
+	req := httptest.NewRequest(http.MethodPost, "/api/move", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	srv.handleMove(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+
+	var payload struct {
+		State   game.BoardState `json:"state"`
+		Message string          `json:"message"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if payload.Message != game.ErrDoOverActivated.Error() {
+		t.Fatalf("expected DoOver message, got %q", payload.Message)
+	}
+	if len(payload.State.Pieces) == 0 {
+		t.Fatalf("expected non-empty state payload")
+	}
+	if payload.State.Turn != game.White {
+		t.Fatalf("expected rewound turn to white, got %s", payload.State.Turn)
+	}
+	if !strings.Contains(strings.ToLower(payload.State.LastNote), "doover") &&
+		!strings.Contains(strings.ToLower(payload.State.LastNote), "do over") {
+		t.Fatalf("expected last note to mention do-over, got %q", payload.State.LastNote)
+	}
+}

--- a/chessTest/web/static/app.js
+++ b/chessTest/web/static/app.js
@@ -257,6 +257,16 @@
       // Optional client animation
       await animateMove(algToSq(from), algToSq(to));
       updateState(result);
+      const softMessage = result && typeof result.message === "string" ? result.message.trim() : "";
+      if (softMessage) {
+        showToast("Notice", softMessage);
+        logEvent("Notice", softMessage);
+        moveError.textContent = softMessage;
+        moveError.className = "warning";
+      } else {
+        moveError.textContent = "";
+        moveError.className = "";
+      }
       sounds.move();
       // Clear selection if success
       selectedSquare = null;

--- a/docs/do_over_manual_qa.md
+++ b/docs/do_over_manual_qa.md
@@ -1,0 +1,9 @@
+<!-- path: docs/do_over_manual_qa.md -->
+# Do-Over Resync Smoke Checklist
+
+- Launch the battle chess web UI and start a new match.
+- Configure both sides with the Do-Over ability and any elements so the match locks in.
+- Play two standard opening moves (e.g., White pawn e2→e4, Black pawn d7→d5).
+- As White, capture the d5 pawn (e4→d5) to trigger the Do-Over ability.
+- Verify the board rewinds to the pre-move state, the turn indicator resets to White, and a toast/log entry displays the Do-Over warning message.
+- Submit another legal move and confirm the board remains in sync with the server state.


### PR DESCRIPTION
## Summary
- return 200 with updated state and message when move resolution hits Do-Over or BlockPath protection
- surface backend soft-warning messages in the web client via toast and event log updates
- add HTTP regression coverage for Do-Over along with a manual QA checklist for resync verification

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68db3334f13c8323950b98b331b9f386