### PR TITLE
Remove unused promotion piece argument

### DIFF
--- a/chessTest/internal/game/engine.go
+++ b/chessTest/internal/game/engine.go
@@ -411,14 +411,14 @@ func (e *Engine) resolvePromotion(pc *Piece) {
 	}
 	if (pc.Color == White && pc.Square.Rank() == 7) || (pc.Color == Black && pc.Square.Rank() == 0) {
 		e.board.pieces[pc.Color][Pawn] = e.board.pieces[pc.Color][Pawn].Remove(pc.Square)
-		promoteTo := e.selectPromotionPiece(pc.Color)
+		promoteTo := e.selectPromotionPiece()
 		pc.Type = promoteTo
 		e.board.pieces[pc.Color][promoteTo] = e.board.pieces[pc.Color][promoteTo].Add(pc.Square)
 		appendAbilityNote(&e.board.lastNote, fmt.Sprintf("Pawn promoted to %s", promoteTo.String()))
 	}
 }
 
-func (e *Engine) selectPromotionPiece(color Color) PieceType {
+func (e *Engine) selectPromotionPiece() PieceType {
 	choices := e.board.PromotionChoices
 	if choices == PromotionNone {
 		choices = PromotionAll


### PR DESCRIPTION
## Summary
- drop the unused color parameter from selectPromotionPiece
- update the pawn promotion call site to match the simplified signature

## Testing
- go test ./chessTest/... (fails: pattern ./chessTest/...: directory prefix chessTest does not contain main module or its selected dependencies)
- (in chessTest) go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68db365e9348832398e596650daedade