### PR TITLE
Simplify post capture termination helper

### DIFF
--- a/chessTest/internal/game/move_capture.go
+++ b/chessTest/internal/game/move_capture.go
@@ -102,7 +102,7 @@ func boolToInt(v bool) int {
 	return 0
 }
 
-func (e *Engine) checkPostCaptureTermination(pc *Piece, target *Piece) bool {
+func (e *Engine) checkPostCaptureTermination() bool {
 	if e.currentMove == nil {
 		return false
 	}

--- a/chessTest/internal/game/move_continuation.go
+++ b/chessTest/internal/game/move_continuation.go
@@ -151,10 +151,10 @@ func (e *Engine) executeSpecialMovePlan(pc *Piece, from, to Square, plan Special
 	if plan.MarkAbilityUsed && plan.Ability != AbilityNone {
 		e.currentMove.markAbilityUsed(plan.Ability)
 	}
-        if plan.ResetResurrection && pc != nil && pc.HasAbility(AbilityResurrection) {
-                e.currentMove.setAbilityFlag(AbilityResurrection, abilityFlagWindow, false)
-                e.currentMove.setAbilityCounter(AbilityResurrection, abilityCounterResurrectionWindow, 0)
-        }
+	if plan.ResetResurrection && pc != nil && pc.HasAbility(AbilityResurrection) {
+		e.currentMove.setAbilityFlag(AbilityResurrection, abilityFlagWindow, false)
+		e.currentMove.setAbilityCounter(AbilityResurrection, abilityCounterResurrectionWindow, 0)
+	}
 
 	segmentStep := len(e.currentMove.Path) - 1
 	if segmentStep < 0 {
@@ -234,7 +234,7 @@ func (e *Engine) executeSpecialMovePlan(pc *Piece, from, to Square, plan Special
 		}
 	}
 
-	if e.checkPostCaptureTermination(pc, plan.Metadata.Capture) {
+	if e.checkPostCaptureTermination() {
 		e.endTurn(TurnEndForced)
 		return nil
 	}
@@ -426,9 +426,9 @@ func (e *Engine) hasFloodWakePushOption(pc *Piece) bool {
 }
 
 func (e *Engine) blazeRushContinuationAvailable(pc *Piece) bool {
-        if pc == nil || !pc.HasAbility(AbilityBlazeRush) {
-                return false
-        }
+	if pc == nil || !pc.HasAbility(AbilityBlazeRush) {
+		return false
+	}
 	if e.currentMove == nil || e.currentMove.abilityUsed(AbilityBlazeRush) || e.currentMove.LastSegmentCaptured {
 		return false
 	}
@@ -455,9 +455,9 @@ func (e *Engine) blazeRushContinuationAvailable(pc *Piece) bool {
 }
 
 func (e *Engine) floodWakeContinuationAvailable(pc *Piece) bool {
-        if pc == nil || !pc.HasAbility(AbilityFloodWake) {
-                return false
-        }
+	if pc == nil || !pc.HasAbility(AbilityFloodWake) {
+		return false
+	}
 	if e.currentMove == nil || e.currentMove.abilityUsed(AbilityFloodWake) {
 		return false
 	}
@@ -520,21 +520,21 @@ func maxInt(a, b int) int {
 }
 
 func (e *Engine) checkPostMoveAbilities(pc *Piece) {
-        if pc.HasAbility(AbilitySideStep) && !e.currentMove.abilityUsed(AbilitySideStep) && e.currentMove.RemainingSteps > 0 {
-                appendAbilityNote(&e.board.lastNote, "Side Step available (costs 1 step)")
-        }
-        if pc.HasAbility(AbilityQuantumStep) && !e.currentMove.abilityUsed(AbilityQuantumStep) && e.currentMove.RemainingSteps > 0 {
-                appendAbilityNote(&e.board.lastNote, "Quantum Step available (costs 1 step)")
-        }
+	if pc.HasAbility(AbilitySideStep) && !e.currentMove.abilityUsed(AbilitySideStep) && e.currentMove.RemainingSteps > 0 {
+		appendAbilityNote(&e.board.lastNote, "Side Step available (costs 1 step)")
+	}
+	if pc.HasAbility(AbilityQuantumStep) && !e.currentMove.abilityUsed(AbilityQuantumStep) && e.currentMove.RemainingSteps > 0 {
+		appendAbilityNote(&e.board.lastNote, "Quantum Step available (costs 1 step)")
+	}
 }
 
 func (e *Engine) isFloodWakePushAvailable(pc *Piece, from, to Square, target *Piece) bool {
-        if pc == nil || target != nil {
-                return false
-        }
-        if !pc.HasAbility(AbilityFloodWake) {
-                return false
-        }
+	if pc == nil || target != nil {
+		return false
+	}
+	if !pc.HasAbility(AbilityFloodWake) {
+		return false
+	}
 	if elementOf(e, pc) != ElementWater {
 		return false
 	}
@@ -550,12 +550,12 @@ func (e *Engine) isFloodWakePushAvailable(pc *Piece, from, to Square, target *Pi
 }
 
 func (e *Engine) isBlazeRushDash(pc *Piece, from, to Square, target *Piece) bool {
-        if pc == nil || target != nil {
-                return false
-        }
-        if !pc.HasAbility(AbilityBlazeRush) {
-                return false
-        }
+	if pc == nil || target != nil {
+		return false
+	}
+	if !pc.HasAbility(AbilityBlazeRush) {
+		return false
+	}
 	if !e.isSlider(pc.Type) {
 		return false
 	}

--- a/chessTest/internal/game/moves.go
+++ b/chessTest/internal/game/moves.go
@@ -163,7 +163,7 @@ func (e *Engine) startNewMove(req MoveRequest) error {
 	e.checkPostMoveAbilities(pc)
 	e.checkPostMoveAbilities(pc)
 
-	if e.checkPostCaptureTermination(pc, segmentCtx.capture) {
+	if e.checkPostCaptureTermination() {
 		e.endTurn(TurnEndForced)
 	} else if e.currentMove.RemainingSteps <= 0 && !e.hasFreeContinuation(pc) {
 		e.endTurn(TurnEndNatural)
@@ -321,7 +321,7 @@ func (e *Engine) continueMove(req MoveRequest) error {
 		}
 	}
 
-	if e.checkPostCaptureTermination(pc, segmentCtx.capture) {
+	if e.checkPostCaptureTermination() {
 		e.endTurn(TurnEndForced)
 	} else if e.currentMove.RemainingSteps <= 0 && !e.hasFreeContinuation(pc) {
 		e.endTurn(TurnEndNatural)


### PR DESCRIPTION
## Summary
- drop the unused parameters from Engine.checkPostCaptureTermination
- update post-move call sites to use the simplified helper

## Testing
- go test ./chessTest/... *(fails: directory prefix chessTest does not contain main module or its selected dependencies)*
- (cd chessTest && go test ./...)


------
https://chatgpt.com/codex/tasks/task_e_68db3e52fe748323a2ff9897faea4fb5