### PR TITLE
Remove unused path clearance helper

### DIFF
--- a/chessTest/internal/game/piece_ops.go
+++ b/chessTest/internal/game/piece_ops.go
@@ -193,16 +193,6 @@ func (e *Engine) removePiece(pc *Piece, sq Square) {
 	delete(e.pendingDoOver, pc.ID)
 }
 
-func (e *Engine) isPathClear(from, to Square) bool {
-	line := Line(from, to)
-	for _, sq := range line {
-		if e.board.pieceAt[sq] != nil {
-			return false
-		}
-	}
-	return true
-}
-
 func (e *Engine) canPhaseThrough(pc *Piece, from Square, to Square) bool {
 	if pc == nil {
 		return false


### PR DESCRIPTION
## Summary
- remove the unused isPathClear helper from the piece operations implementation

## Testing
- go test ./... (from chessTest)


------
https://chatgpt.com/codex/tasks/task_e_68db480d41948323a057925fa77a64bf