### PR TITLE
Clean up unused move helpers

### DIFF
--- a/chessTest/internal/game/move_state.go
+++ b/chessTest/internal/game/move_state.go
@@ -74,10 +74,6 @@ func (ms *MoveState) markAbilityUsed(id Ability) {
 	ms.setAbilityFlag(id, abilityFlagUsed, true)
 }
 
-func (ms *MoveState) clearAbilityUsed(id Ability) {
-	ms.setAbilityFlag(id, abilityFlagUsed, false)
-}
-
 func (ms *MoveState) abilityCounter(id Ability, key abilityCounterIndex) int {
 	if ms == nil {
 		return 0

--- a/chessTest/internal/game/moves.go
+++ b/chessTest/internal/game/moves.go
@@ -71,7 +71,7 @@ func (e *Engine) startNewMove(req MoveRequest) error {
 	if err != nil {
 		return err
 	}
-	firstSegmentCost := e.calculateMovementCost(pc, from, to)
+	firstSegmentCost := e.calculateMovementCost(from, to)
 	remainingSteps := totalSteps - firstSegmentCost
 	if remainingSteps < 0 {
 		remainingSteps = 0
@@ -207,7 +207,7 @@ func (e *Engine) continueMove(req MoveRequest) error {
 		return errors.New("illegal move continuation")
 	}
 
-	stepsNeeded := e.calculateMovementCost(pc, from, to)
+	stepsNeeded := e.calculateMovementCost(from, to)
 	target := e.board.pieceAt[to]
 	if target != nil && target.Color == pc.Color {
 		return errors.New("cannot capture a friendly piece")

--- a/chessTest/internal/game/step_budget.go
+++ b/chessTest/internal/game/step_budget.go
@@ -72,7 +72,7 @@ func (e *Engine) calculateStepBudget(pc *Piece, handlers *abilityHandlerTable) (
 	return total, notes, nil
 }
 
-func (e *Engine) calculateMovementCost(pc *Piece, from, to Square) int {
+func (e *Engine) calculateMovementCost(from, to Square) int {
 	cost := 1
 
 	if e.currentMove != nil && e.wouldChangeDirection(e.currentMove, from, to) {


### PR DESCRIPTION
## Summary
- remove the unused MoveState.clearAbilityUsed helper
- drop the unused piece parameter from calculateMovementCost and its callers

## Testing
- go test ./... (fails: hangs indefinitely, aborted)


------
https://chatgpt.com/codex/tasks/task_e_68db4b7e57f08323a2b1a69d102f5292