### PR TITLE
Support spaced ability aliases in HTTP config

### DIFF
--- a/chessTest/internal/httpx/server.go
+++ b/chessTest/internal/httpx/server.go
@@ -354,6 +354,9 @@ func parseColor(s string) (game.Color, bool) {
 }
 
 func parseAbility(s string) (game.Ability, bool) {
+	if ability, ok := game.ParseAbility(s); ok {
+		return ability, true
+	}
 	if s == "" {
 		return game.AbilityNone, false
 	}


### PR DESCRIPTION
## Summary
- ensure HTTP config parsing defers to game.ParseAbility so spaced aliases are accepted
- cover both CamelCase and spaced ability payloads in a table-driven configuration test and validate Engine state

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68db604cc984832381aa71227b3603e7