### PR TITLE
Align bishop rank with rook and add belligerent regression test

### DIFF
--- a/chessTest/internal/game/engine.go
+++ b/chessTest/internal/game/engine.go
@@ -431,7 +431,7 @@ func (e *Engine) selectPromotionPiece() PieceType {
 
 func (e *Engine) isSlider(pt PieceType) bool { return pt == Queen || pt == Rook || pt == Bishop }
 
-var RankOrder = map[PieceType]int{King: 5, Queen: 4, Rook: 3, Bishop: 2, Knight: 2, Pawn: 1}
+var RankOrder = map[PieceType]int{King: 5, Queen: 4, Rook: 3, Bishop: 3, Knight: 2, Pawn: 1}
 
 func rankOf(pt PieceType) int { return RankOrder[pt] }
 

--- a/chessTest/internal/game/moves_test.go
+++ b/chessTest/internal/game/moves_test.go
@@ -1039,6 +1039,35 @@ func TestBelligerentBlocksHigherRankCapture(t *testing.T) {
 	}
 }
 
+func TestBelligerentKnightCannotCaptureBishop(t *testing.T) {
+	eng := NewEngine()
+	if err := eng.SetSideConfig(White, AbilityList{AbilityBelligerent}, ElementLight); err != nil {
+		t.Fatalf("configure white: %v", err)
+	}
+	if err := eng.SetSideConfig(Black, AbilityList{AbilityDoOver}, ElementShadow); err != nil {
+		t.Fatalf("configure black: %v", err)
+	}
+
+	clearBoard(eng)
+
+	knightSq := mustSquare(t, "c3")
+	bishopSq := mustSquare(t, "e4")
+
+	eng.placePiece(White, Knight, knightSq)
+	eng.placePiece(Black, Bishop, bishopSq)
+	eng.board.turn = White
+
+	if err := eng.Move(MoveRequest{From: knightSq, To: bishopSq, Dir: DirNone}); err == nil {
+		t.Fatalf("expected belligerent knight capture of bishop to be rejected")
+	}
+	if pc := eng.board.pieceAt[knightSq]; pc == nil || pc.Color != White || pc.Type != Knight {
+		t.Fatalf("expected white knight to remain on %s", knightSq.String())
+	}
+	if pc := eng.board.pieceAt[bishopSq]; pc == nil || pc.Color != Black || pc.Type != Bishop {
+		t.Fatalf("expected black bishop to remain on %s", bishopSq.String())
+	}
+}
+
 func TestBelligerentAllowsEqualRankCapture(t *testing.T) {
 	eng := NewEngine()
 	if err := eng.SetSideConfig(White, AbilityList{AbilitySideStep}, ElementLight); err != nil {


### PR DESCRIPTION
## Summary
- update the engine rank table so bishops share rank 3 with rooks
- add a regression test ensuring a Belligerent knight cannot capture a bishop

## Testing
- go test ./internal/game -run Test.*

------
https://chatgpt.com/codex/tasks/task_e_68db67b66e048323ad2bfcb47d67d192