### PR TITLE
Allow Double Kill extra capture against earth-aligned targets

### DIFF
--- a/chessTest/internal/game/ability_resolver.go
+++ b/chessTest/internal/game/ability_resolver.go
@@ -44,7 +44,7 @@ func (e *Engine) trySmartExtraCapture(attacker *Piece, captureSquare Square, vic
 		if !e.canAbilityRemove(attacker, p) {
 			continue
 		}
-		if elementOf(e, p) == ElementEarth || p.HasAbility(AbilityObstinant) || e.sideHasAbility(p.Color, AbilityObstinant) {
+		if p.HasAbility(AbilityObstinant) || e.sideHasAbility(p.Color, AbilityObstinant) {
 			continue
 		}
 		r := rankOf(p.Type)

--- a/chessTest/internal/game/moves_test.go
+++ b/chessTest/internal/game/moves_test.go
@@ -876,6 +876,35 @@ func TestQuantumKillRemoteRemovalHonorsRank(t *testing.T) {
 	}
 }
 
+func TestDoubleKillExtraRemovalIgnoresEarthAlignment(t *testing.T) {
+	eng := NewEngine()
+	if err := eng.SetSideConfig(White, AbilityList{AbilityDoubleKill}, ElementLight); err != nil {
+		t.Fatalf("configure white: %v", err)
+	}
+	if err := eng.SetSideConfig(Black, AbilityList{AbilityStalwart}, ElementEarth); err != nil {
+		t.Fatalf("configure black: %v", err)
+	}
+
+	clearBoard(eng)
+
+	attackerSq := mustSquare(t, "e4")
+	victimSq := mustSquare(t, "e5")
+	extraSq := mustSquare(t, "e6")
+
+	eng.placePiece(White, Queen, attackerSq)
+	eng.placePiece(Black, Rook, victimSq)
+	eng.placePiece(Black, Pawn, extraSq)
+	eng.board.turn = White
+
+	if err := eng.Move(MoveRequest{From: attackerSq, To: victimSq, Dir: DirNone}); err != nil {
+		t.Fatalf("double kill capture: %v", err)
+	}
+
+	if eng.board.pieceAt[extraSq] != nil {
+		t.Fatalf("expected extra removal at %s to succeed", extraSq)
+	}
+}
+
 func TestScatterShotAllowsSideCapture(t *testing.T) {
 	eng := NewEngine()
 	if err := eng.SetSideConfig(White, AbilityList{AbilityScatterShot}, ElementAir); err != nil {


### PR DESCRIPTION
## Summary
- remove the Earth alignment exclusion in smart extra capture selection so Double Kill can pick valid adjacent victims
- add a regression move test configuring Double Kill versus an Earth-aligned defender to confirm the extra removal succeeds

## Testing
- go test ./internal/game

------
https://chatgpt.com/codex/tasks/task_e_68db8b30335c8323a24e9163805496e6