### PR TITLE
Implement phased ability resolver with extensive tests

### DIFF
--- a/chessTest/internal/game/ability_registry.go
+++ b/chessTest/internal/game/ability_registry.go
@@ -191,6 +191,13 @@ const (
 	AbilityScorch
 	AbilityBlazeRush
 	AbilityFloodWake
+	AbilityBastion
+	AbilitySturdy
+	AbilityGaleLift
+	AbilityRaijin
+	AbilityBlinding
+	AbilityAnarchist
+	AbilitySadist
 	abilityCount
 )
 
@@ -236,6 +243,13 @@ var abilityCatalog = []abilityEntry{
 	{AbilityScorch, "Scorch", nil},
 	{AbilityBlazeRush, "BlazeRush", []string{"blaze rush"}},
 	{AbilityFloodWake, "FloodWake", []string{"flood wake"}},
+	{AbilityBastion, "Bastion", nil},
+	{AbilitySturdy, "Sturdy", nil},
+	{AbilityGaleLift, "GaleLift", []string{"gale lift"}},
+	{AbilityRaijin, "Raijin", nil},
+	{AbilityBlinding, "Blinding", nil},
+	{AbilityAnarchist, "Anarchist", nil},
+	{AbilitySadist, "Sadist", nil},
 }
 
 var abilityNameByID map[Ability]string

--- a/chessTest/internal/game/ability_resolver.go
+++ b/chessTest/internal/game/ability_resolver.go
@@ -1,6 +1,128 @@
 // path: chessTest/internal/game/ability_resolver.go
 package game
 
+import "math/bits"
+
+const (
+	abilityCountInt  = int(abilityCount)
+	phaseCount       = 5
+	maxPhaseEntries  = 16
+	overloadCapacity = 16
+)
+
+type abilityPhase uint8
+
+const (
+	phaseElemental abilityPhase = iota
+	phaseAugmentor
+	phaseOffense
+	phaseTemporal
+	phaseResolution
+)
+
+type rngState struct{ seed uint64 }
+
+func newRNG(seed uint64) rngState {
+	if seed == 0 {
+		seed = 1
+	}
+	return rngState{seed: seed}
+}
+
+func (r *rngState) next() uint32 {
+	s := r.seed
+	s ^= s << 7
+	s ^= s >> 9
+	s ^= s << 8
+	r.seed = s
+	return uint32(s)
+}
+
+type phaseScratch struct {
+	ability  [maxPhaseEntries]Ability
+	owner    [maxPhaseEntries]Color
+	piece    [maxPhaseEntries]int8
+	priority [maxPhaseEntries]uint8
+	count    uint8
+}
+
+func (p *phaseScratch) reset() { p.count = 0 }
+
+func (p *phaseScratch) push(id Ability, owner Color, piece int, pri uint8) {
+	if p.count >= maxPhaseEntries {
+		return
+	}
+	p.ability[p.count] = id
+	p.owner[p.count] = owner
+	p.piece[p.count] = int8(piece)
+	p.priority[p.count] = pri
+	p.count++
+}
+
+func (p *phaseScratch) sort() {
+	for i := 1; i < int(p.count); i++ {
+		pri := p.priority[i]
+		ability := p.ability[i]
+		owner := p.owner[i]
+		piece := p.piece[i]
+		j := i - 1
+		for j >= 0 {
+			if p.priority[j] <= pri {
+				break
+			}
+			p.priority[j+1] = p.priority[j]
+			p.ability[j+1] = p.ability[j]
+			p.owner[j+1] = p.owner[j]
+			p.piece[j+1] = p.piece[j]
+			j--
+		}
+		p.priority[j+1] = pri
+		p.ability[j+1] = ability
+		p.owner[j+1] = owner
+		p.piece[j+1] = piece
+	}
+}
+
+type phaseExecution struct {
+	abilities [maxPhaseEntries]Ability
+	owners    [maxPhaseEntries]Color
+	count     uint8
+}
+
+func (p *phaseExecution) record(id Ability, owner Color) {
+	if p.count >= maxPhaseEntries {
+		return
+	}
+	p.abilities[p.count] = id
+	p.owners[p.count] = owner
+	p.count++
+}
+
+type resolveTelemetry struct {
+	phaseLogs           [phaseCount]phaseExecution
+	firewallSquares     [4]Square
+	firewallCount       uint8
+	blazeDK             uint8
+	blazeQK             uint8
+	floodWakePersistent bool
+	mistShroudQS        uint8
+	bastion             bool
+	sturdy              bool
+	gale                bool
+	tailwindBridge      bool
+	scatterHits         uint8
+	overload            [overloadCapacity]Ability
+	overloadCount       uint8
+	raijinFollow        bool
+	radiantVision       bool
+	blindingSkipped     bool
+	anarchist           Ability
+	sadist              Ability
+	ck                  PieceType
+	qk                  PieceType
+	dk                  PieceType
+}
+
 type resolveContext struct {
 	board        *boardSoA
 	mover        int
@@ -10,30 +132,439 @@ type resolveContext struct {
 	enemyMask    AbilitySet
 	doOverUsed   *[2]bool
 	requestedDir Direction
+	sideElement  Element
+	enemyElement Element
+	seed         uint64
+	elemental    phaseScratch
+	augmentor    phaseScratch
+	offense      phaseScratch
+	temporal     phaseScratch
+	resolution   phaseScratch
+	rng          rngState
 }
 
 type resolveResult struct {
-	doOver   bool
-	blockDir Direction
-	setBlock bool
+	doOver    bool
+	blockDir  Direction
+	setBlock  bool
+	telemetry resolveTelemetry
+}
+
+type abilitySource struct {
+	color Color
+	mask  AbilitySet
+	piece int
+}
+
+type sideState struct {
+	mask     AbilitySet
+	piece    AbilitySet
+	combined AbilitySet
+	element  Element
+}
+
+type resolveState struct {
+	moverColor Color
+	enemyColor Color
+	sides      [2]sideState
+	floodWake  [2]bool
+	tailwind   [2]bool
+	mist       [2]bool
+	lightSpeed [2]bool
+	bastion    [2]bool
+	sturdy     [2]bool
+	override   Ability
+}
+
+type abilityHandler func(*resolveContext, *resolveResult, *resolveState, abilitySource)
+
+type abilityMeta struct {
+	phase        abilityPhase
+	basePriority uint8
+	handler      abilityHandler
+}
+
+var abilityMetaTable = [abilityCountInt]abilityMeta{
+	AbilityDoOver:        {phaseTemporal, 1, handleDoOver},
+	AbilityBlockPath:     {phaseResolution, 2, handleBlockPath},
+	AbilityMistShroud:    {phaseAugmentor, 1, handleMistShroud},
+	AbilityTailwind:      {phaseAugmentor, 2, handleTailwind},
+	AbilityScatterShot:   {phaseOffense, 2, handleScatterShot},
+	AbilityOverload:      {phaseAugmentor, 3, handleOverload},
+	AbilityRadiantVision: {phaseElemental, 2, handleRadiantVision},
+	AbilityLightSpeed:    {phaseOffense, 0, handleLightSpeed},
+	AbilityScorch:        {phaseElemental, 1, handleScorch},
+	AbilityBlazeRush:     {phaseOffense, 1, handleBlazeRush},
+	AbilityFloodWake:     {phaseElemental, 0, handleFloodWake},
+	AbilityBastion:       {phaseAugmentor, 0, handleBastion},
+	AbilitySturdy:        {phaseAugmentor, 1, handleSturdy},
+	AbilityGaleLift:      {phaseAugmentor, 2, handleGaleLift},
+	AbilityRaijin:        {phaseOffense, 3, handleRaijin},
+	AbilityBlinding:      {phaseTemporal, 2, handleBlinding},
+	AbilityAnarchist:     {phaseResolution, 0, handleAnarchist},
+	AbilitySadist:        {phaseResolution, 1, handleSadist},
 }
 
 type abilityResolver struct{}
 
-func newAbilityResolver() abilityResolver {
-	return abilityResolver{}
+func newAbilityResolver() abilityResolver { return abilityResolver{} }
+
+func (r abilityResolver) resolve(ctx resolveContext) (resolveResult, error) {
+	var res resolveResult
+	state, err := r.initState(&ctx)
+	if err != nil {
+		return res, err
+	}
+	r.collect(&ctx, &state)
+	r.runPhase(&ctx, &state, phaseElemental, &ctx.elemental, &res)
+	r.runPhase(&ctx, &state, phaseAugmentor, &ctx.augmentor, &res)
+	r.runPhase(&ctx, &state, phaseOffense, &ctx.offense, &res)
+	r.runPhase(&ctx, &state, phaseTemporal, &ctx.temporal, &res)
+	r.runPhase(&ctx, &state, phaseResolution, &ctx.resolution, &res)
+	r.finalize(&ctx, &state, &res)
+	return res, nil
 }
 
-func (r abilityResolver) resolve(ctx resolveContext) resolveResult {
-	if ctx.captureIdx >= 0 && ctx.enemyMask.Has(AbilityDoOver) {
-		color := ctx.board.colors[ctx.captureIdx]
-		if !ctx.doOverUsed[color.Index()] {
-			ctx.doOverUsed[color.Index()] = true
-			return resolveResult{doOver: true}
+func (abilityResolver) initState(ctx *resolveContext) (resolveState, error) {
+	var state resolveState
+	state.moverColor = ctx.board.colors[ctx.mover]
+	state.enemyColor = state.moverColor.Opposite()
+	moverIdx := state.moverColor.Index()
+	enemyIdx := state.enemyColor.Index()
+	rawMoverMask := ctx.board.ability[ctx.mover]
+	moverPieceMask := rawMoverMask
+	if moverPieceMask == 0 {
+		moverPieceMask = ctx.sideMask
+	}
+	enemyPieceMask := AbilitySet(0)
+	if ctx.captureIdx >= 0 {
+		enemyPieceMask = ctx.board.ability[ctx.captureIdx]
+	}
+	if enemyPieceMask == 0 {
+		enemyPieceMask = ctx.enemyMask
+	}
+	state.sides[moverIdx] = sideState{
+		mask:     ctx.sideMask,
+		piece:    moverPieceMask,
+		combined: moverPieceMask | ctx.sideMask,
+		element:  ctx.sideElement,
+	}
+	state.sides[enemyIdx] = sideState{
+		mask:     ctx.enemyMask,
+		piece:    enemyPieceMask,
+		combined: enemyPieceMask | ctx.enemyMask,
+		element:  ctx.enemyElement,
+	}
+	moverCombined := state.sides[moverIdx].combined
+	if moverCombined.Has(AbilityMistShroud) && moverCombined.Has(AbilityRadiantVision) {
+		return state, ErrConflictingAugmentors
+	}
+	if moverCombined.Has(AbilityOverload) && rawMoverMask == 0 {
+		return state, ErrInvalidOverload
+	}
+	ctx.rng = newRNG(ctx.seed ^ uint64(ctx.board.ids[ctx.mover])<<1 ^ uint64(ctx.target))
+	state.floodWake[moverIdx] = moverCombined.Has(AbilityFloodWake)
+	state.floodWake[enemyIdx] = state.sides[enemyIdx].combined.Has(AbilityFloodWake)
+	state.tailwind[moverIdx] = moverCombined.Has(AbilityTailwind)
+	state.tailwind[enemyIdx] = state.sides[enemyIdx].combined.Has(AbilityTailwind)
+	state.mist[moverIdx] = moverCombined.Has(AbilityMistShroud)
+	state.mist[enemyIdx] = state.sides[enemyIdx].combined.Has(AbilityMistShroud)
+	state.lightSpeed[moverIdx] = moverCombined.Has(AbilityLightSpeed)
+	state.lightSpeed[enemyIdx] = state.sides[enemyIdx].combined.Has(AbilityLightSpeed)
+	return state, nil
+}
+
+func (abilityResolver) collect(ctx *resolveContext, state *resolveState) {
+	ctx.elemental.reset()
+	ctx.augmentor.reset()
+	ctx.offense.reset()
+	ctx.temporal.reset()
+	ctx.resolution.reset()
+	moverPiece := ctx.mover
+	enemyPiece := -1
+	if ctx.captureIdx >= 0 {
+		enemyPiece = ctx.captureIdx
+	}
+	abilityResolverQueue(ctx, state, state.moverColor, moverPiece, state.sides[state.moverColor.Index()].combined)
+	abilityResolverQueue(ctx, state, state.enemyColor, enemyPiece, state.sides[state.enemyColor.Index()].combined)
+}
+
+func abilityResolverQueue(ctx *resolveContext, state *resolveState, color Color, piece int, mask AbilitySet) {
+	if mask == 0 {
+		return
+	}
+	idx := color.Index()
+	for ability := Ability(1); ability < abilityCount; ability++ {
+		if !mask.Has(ability) {
+			continue
+		}
+		meta := abilityMetaTable[int(ability)]
+		if meta.handler == nil {
+			continue
+		}
+		priority := meta.basePriority
+		if state.lightSpeed[idx] {
+			priority = 0
+		}
+		switch meta.phase {
+		case phaseElemental:
+			ctx.elemental.push(ability, color, piece, priority)
+		case phaseAugmentor:
+			ctx.augmentor.push(ability, color, piece, priority)
+		case phaseOffense:
+			ctx.offense.push(ability, color, piece, priority)
+		case phaseTemporal:
+			ctx.temporal.push(ability, color, piece, priority)
+		case phaseResolution:
+			ctx.resolution.push(ability, color, piece, priority)
 		}
 	}
-	if ctx.sideMask.Has(AbilityBlockPath) && ctx.requestedDir != DirNone {
-		return resolveResult{blockDir: ctx.requestedDir, setBlock: true}
+}
+
+func (r abilityResolver) runPhase(ctx *resolveContext, state *resolveState, phase abilityPhase, scratch *phaseScratch, res *resolveResult) {
+	if scratch.count == 0 {
+		return
 	}
-	return resolveResult{}
+	scratch.sort()
+	for i := uint8(0); i < scratch.count; i++ {
+		ability := scratch.ability[i]
+		owner := scratch.owner[i]
+		idx := owner.Index()
+		piece := int(scratch.piece[i])
+		meta := abilityMetaTable[int(ability)]
+		if meta.handler != nil {
+			src := abilitySource{color: owner, mask: state.sides[idx].combined, piece: piece}
+			meta.handler(ctx, res, state, src)
+		}
+		res.telemetry.phaseLogs[int(phase)].record(ability, owner)
+	}
+}
+
+func (abilityResolver) finalize(ctx *resolveContext, state *resolveState, res *resolveResult) {
+	moverIdx := state.moverColor.Index()
+	enemyIdx := state.enemyColor.Index()
+	if state.tailwind[moverIdx] && state.mist[moverIdx] {
+		res.telemetry.tailwindBridge = true
+	}
+	if state.tailwind[enemyIdx] && state.mist[enemyIdx] {
+		res.telemetry.tailwindBridge = true
+	}
+	if res.telemetry.floodWakePersistent || state.floodWake[moverIdx] {
+		res.telemetry.floodWakePersistent = true
+	}
+	if state.lightSpeed[enemyIdx] && !state.lightSpeed[moverIdx] {
+		res.telemetry.ck = Knight
+		res.telemetry.qk = Queen
+		res.telemetry.dk = King
+	} else {
+		res.telemetry.ck = King
+		res.telemetry.qk = Queen
+		res.telemetry.dk = Knight
+	}
+	if res.doOver {
+		res.telemetry.floodWakePersistent = res.telemetry.floodWakePersistent || state.floodWake[enemyIdx]
+	}
+}
+
+func handleDoOver(ctx *resolveContext, res *resolveResult, state *resolveState, src abilitySource) {
+	if ctx.captureIdx < 0 {
+		return
+	}
+	color := ctx.board.colors[ctx.captureIdx]
+	idx := color.Index()
+	if (*ctx.doOverUsed)[idx] {
+		return
+	}
+	(*ctx.doOverUsed)[idx] = true
+	res.doOver = true
+	if state.floodWake[idx] {
+		res.telemetry.floodWakePersistent = true
+	}
+}
+
+func handleBlockPath(ctx *resolveContext, res *resolveResult, _ *resolveState, src abilitySource) {
+	if src.color != ctx.board.colors[ctx.mover] {
+		return
+	}
+	if ctx.requestedDir == DirNone {
+		return
+	}
+	res.blockDir = ctx.requestedDir
+	res.setBlock = true
+}
+
+func handleMistShroud(_ *resolveContext, res *resolveResult, state *resolveState, src abilitySource) {
+	idx := src.color.Index()
+	state.mist[idx] = true
+	res.telemetry.mistShroudQS++
+}
+
+func handleTailwind(_ *resolveContext, res *resolveResult, state *resolveState, src abilitySource) {
+	idx := src.color.Index()
+	state.tailwind[idx] = true
+	if state.mist[idx] {
+		res.telemetry.tailwindBridge = true
+	}
+}
+
+func handleScatterShot(ctx *resolveContext, res *resolveResult, state *resolveState, src abilitySource) {
+	enemy := src.color.Opposite()
+	dirs := [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	start := int(ctx.rng.next() % uint32(len(dirs)))
+	for n := 0; n < len(dirs); n++ {
+		dir := dirs[(start+n)%len(dirs)]
+		sq := offsetSquare(ctx.target, dir[1], dir[0])
+		if sq == SquareInvalid {
+			continue
+		}
+		idx := ctx.board.pieceIndexBySquare(sq)
+		if idx < 0 || ctx.board.colors[idx] != enemy {
+			continue
+		}
+		ctx.board.removePiece(idx)
+		if res.telemetry.scatterHits < 4 {
+			res.telemetry.scatterHits++
+		}
+	}
+	_ = state
+}
+
+func handleOverload(ctx *resolveContext, res *resolveResult, state *resolveState, src abilitySource) {
+	idx := src.color.Index()
+	res.telemetry.overloadCount = 0
+	for i := range ctx.board.ids {
+		if !ctx.board.alive[i] || ctx.board.colors[i] != src.color {
+			continue
+		}
+		mask := ctx.board.ability[i]
+		if mask == 0 {
+			mask = state.sides[idx].mask
+		}
+		ability := firstAbility(mask)
+		if ability == AbilityNone {
+			continue
+		}
+		if res.telemetry.overloadCount >= overloadCapacity {
+			break
+		}
+		res.telemetry.overload[res.telemetry.overloadCount] = ability
+		res.telemetry.overloadCount++
+	}
+}
+
+func handleRadiantVision(_ *resolveContext, res *resolveResult, _ *resolveState, _ abilitySource) {
+	res.telemetry.radiantVision = true
+}
+
+func handleLightSpeed(_ *resolveContext, _ *resolveResult, state *resolveState, src abilitySource) {
+	state.lightSpeed[src.color.Index()] = true
+}
+
+func handleScorch(ctx *resolveContext, res *resolveResult, _ *resolveState, _ abilitySource) {
+	offsets := [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	count := res.telemetry.firewallCount
+	for _, delta := range offsets {
+		if count >= uint8(len(res.telemetry.firewallSquares)) {
+			break
+		}
+		sq := offsetSquare(ctx.target, delta[1], delta[0])
+		if sq == SquareInvalid {
+			continue
+		}
+		res.telemetry.firewallSquares[count] = sq
+		count++
+	}
+	res.telemetry.firewallCount = count
+}
+
+func handleBlazeRush(ctx *resolveContext, res *resolveResult, _ *resolveState, src abilitySource) {
+	if src.piece < 0 {
+		return
+	}
+	switch ctx.board.types[src.piece] {
+	case Knight:
+		if res.telemetry.blazeQK < 3 {
+			res.telemetry.blazeQK++
+		}
+	case Queen:
+		if res.telemetry.blazeDK < 3 {
+			res.telemetry.blazeDK++
+		}
+	default:
+		if res.telemetry.blazeDK < 3 {
+			res.telemetry.blazeDK++
+		}
+	}
+}
+
+func handleFloodWake(_ *resolveContext, res *resolveResult, state *resolveState, src abilitySource) {
+	idx := src.color.Index()
+	state.floodWake[idx] = true
+	res.telemetry.floodWakePersistent = true
+}
+
+func handleBastion(_ *resolveContext, res *resolveResult, state *resolveState, src abilitySource) {
+	idx := src.color.Index()
+	state.bastion[idx] = true
+	res.telemetry.bastion = true
+}
+
+func handleSturdy(_ *resolveContext, res *resolveResult, state *resolveState, src abilitySource) {
+	idx := src.color.Index()
+	state.sturdy[idx] = true
+	res.telemetry.sturdy = true
+}
+
+func handleGaleLift(_ *resolveContext, res *resolveResult, state *resolveState, src abilitySource) {
+	idx := src.color.Index()
+	if state.bastion[idx] && state.sturdy[idx] {
+		res.telemetry.gale = true
+	}
+}
+
+func handleRaijin(_ *resolveContext, res *resolveResult, _ *resolveState, _ abilitySource) {
+	res.telemetry.raijinFollow = true
+}
+
+func handleBlinding(_ *resolveContext, res *resolveResult, _ *resolveState, _ abilitySource) {
+	res.telemetry.blindingSkipped = true
+}
+
+func handleAnarchist(_ *resolveContext, res *resolveResult, state *resolveState, _ abilitySource) {
+	state.override = AbilityScatterShot
+	res.telemetry.anarchist = AbilityScatterShot
+}
+
+func handleSadist(_ *resolveContext, res *resolveResult, state *resolveState, _ abilitySource) {
+	if state.override != AbilityNone {
+		res.telemetry.sadist = state.override
+	} else {
+		res.telemetry.sadist = AbilitySadist
+	}
+}
+
+func firstAbility(set AbilitySet) Ability {
+	bitsVal := uint64(set)
+	if bitsVal == 0 {
+		return AbilityNone
+	}
+	idx := bits.TrailingZeros64(bitsVal)
+	if idx <= 0 {
+		return AbilityNone
+	}
+	return Ability(idx)
+}
+
+func offsetSquare(base Square, rankDelta, fileDelta int) Square {
+	if base == SquareInvalid {
+		return SquareInvalid
+	}
+	rank := int(base) / 8
+	file := int(base) % 8
+	rank += rankDelta
+	file += fileDelta
+	if rank < 0 || rank >= 8 || file < 0 || file >= 8 {
+		return SquareInvalid
+	}
+	return Square(rank*8 + file)
 }

--- a/chessTest/internal/game/ability_resolver_test.go
+++ b/chessTest/internal/game/ability_resolver_test.go
@@ -1,0 +1,327 @@
+// path: chessTest/internal/game/ability_resolver_test.go
+package game
+
+import "testing"
+
+func newEmptyBoard() boardSoA {
+	var b boardSoA
+	for i := range b.alive {
+		b.alive[i] = false
+	}
+	return b
+}
+
+func addPiece(b *boardSoA, idx int, id int, color Color, typ PieceType, sq Square) {
+	b.ids[idx] = id
+	b.alive[idx] = true
+	b.colors[idx] = color
+	b.types[idx] = typ
+	b.squares[idx] = sq
+	bit := uint64(1) << uint(sq)
+	b.occupancy[color.Index()] |= bit
+	b.pieceMask[color.Index()][typ] |= bit
+}
+
+func TestAbilityResolverPhases(t *testing.T) {
+	cases := []struct {
+		name   string
+		side   AbilitySet
+		enemy  AbilitySet
+		setup  func(*boardSoA, *resolveContext)
+		expect func(*testing.T, resolveResult, error, *boardSoA, *resolveContext)
+	}{
+		{
+			name: "scorch firewall",
+			side: NewAbilitySet(AbilityScorch),
+			expect: func(t *testing.T, res resolveResult, err error, _ *boardSoA, _ *resolveContext) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if res.telemetry.firewallCount != 4 {
+					t.Fatalf("expected 4 firewalls, got %d", res.telemetry.firewallCount)
+				}
+				want := map[Square]struct{}{SquareF4: {}, SquareD4: {}, SquareE5: {}, SquareE3: {}}
+				for i := uint8(0); i < res.telemetry.firewallCount; i++ {
+					sq := res.telemetry.firewallSquares[i]
+					if _, ok := want[sq]; !ok {
+						t.Fatalf("unexpected firewall square %v", sq)
+					}
+				}
+			},
+		},
+		{
+			name: "blaze rush quick knight",
+			side: NewAbilitySet(AbilityBlazeRush),
+			expect: func(t *testing.T, res resolveResult, err error, _ *boardSoA, _ *resolveContext) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if res.telemetry.blazeQK != 1 {
+					t.Fatalf("expected quick knight bonus, got %d", res.telemetry.blazeQK)
+				}
+			},
+		},
+		{
+			name: "blaze rush dark queen",
+			side: NewAbilitySet(AbilityBlazeRush),
+			setup: func(b *boardSoA, _ *resolveContext) {
+				b.types[0] = Queen
+			},
+			expect: func(t *testing.T, res resolveResult, err error, _ *boardSoA, _ *resolveContext) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if res.telemetry.blazeDK != 1 {
+					t.Fatalf("expected dark knight bonus, got %d", res.telemetry.blazeDK)
+				}
+			},
+		},
+		{
+			name:  "flood wake do-over",
+			side:  NewAbilitySet(AbilityFloodWake),
+			enemy: NewAbilitySet(AbilityDoOver),
+			setup: func(b *boardSoA, ctx *resolveContext) {
+				addPiece(b, 1, 2, Black, Pawn, ctx.target)
+				ctx.captureIdx = 1
+				b.ability[1] = ctx.enemyMask
+				b.removePiece(1)
+			},
+			expect: func(t *testing.T, res resolveResult, err error, _ *boardSoA, ctx *resolveContext) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !res.doOver {
+					t.Fatalf("expected do-over trigger")
+				}
+				if !res.telemetry.floodWakePersistent {
+					t.Fatalf("expected flood wake persistence")
+				}
+				if !ctx.doOverUsed[Black.Index()] {
+					t.Fatalf("expected do-over usage recorded")
+				}
+			},
+		},
+		{
+			name: "mist tailwind synergy",
+			side: NewAbilitySet(AbilityMistShroud, AbilityTailwind),
+			expect: func(t *testing.T, res resolveResult, err error, _ *boardSoA, _ *resolveContext) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if res.telemetry.mistShroudQS == 0 {
+					t.Fatalf("expected mist shroud grant")
+				}
+				if !res.telemetry.tailwindBridge {
+					t.Fatalf("expected tailwind synergy")
+				}
+			},
+		},
+		{
+			name: "bastion sturdy gale",
+			side: NewAbilitySet(AbilityBastion, AbilitySturdy, AbilityGaleLift),
+			expect: func(t *testing.T, res resolveResult, err error, _ *boardSoA, _ *resolveContext) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !res.telemetry.bastion || !res.telemetry.sturdy || !res.telemetry.gale {
+					t.Fatalf("expected bastion/sturdy/gale interaction")
+				}
+			},
+		},
+		{
+			name: "scatter shot captures",
+			side: NewAbilitySet(AbilityScatterShot),
+			setup: func(b *boardSoA, ctx *resolveContext) {
+				addPiece(b, 1, 3, Black, Pawn, SquareF4)
+				addPiece(b, 2, 4, Black, Pawn, SquareE5)
+			},
+			expect: func(t *testing.T, res resolveResult, err error, b *boardSoA, _ *resolveContext) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if res.telemetry.scatterHits != 2 {
+					t.Fatalf("expected 2 scatter captures, got %d", res.telemetry.scatterHits)
+				}
+				if b.alive[1] || b.alive[2] {
+					t.Fatalf("expected adjacent enemies removed")
+				}
+			},
+		},
+		{
+			name: "overload assignments",
+			side: NewAbilitySet(AbilityOverload),
+			setup: func(b *boardSoA, _ *resolveContext) {
+				addPiece(b, 1, 5, White, Pawn, SquareC3)
+				b.ability[0] = NewAbilitySet(AbilityTailwind)
+				b.ability[1] = NewAbilitySet(AbilityScorch)
+			},
+			expect: func(t *testing.T, res resolveResult, err error, _ *boardSoA, _ *resolveContext) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if res.telemetry.overloadCount != 2 {
+					t.Fatalf("expected overload count 2, got %d", res.telemetry.overloadCount)
+				}
+				if res.telemetry.overload[0] != AbilityTailwind || res.telemetry.overload[1] != AbilityScorch {
+					t.Fatalf("unexpected overload assignments %v %v", res.telemetry.overload[0], res.telemetry.overload[1])
+				}
+			},
+		},
+		{
+			name: "raijin follow",
+			side: NewAbilitySet(AbilityRaijin),
+			expect: func(t *testing.T, res resolveResult, err error, _ *boardSoA, _ *resolveContext) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !res.telemetry.raijinFollow {
+					t.Fatalf("expected raijin follow-up")
+				}
+			},
+		},
+		{
+			name: "radiant vision",
+			side: NewAbilitySet(AbilityRadiantVision),
+			expect: func(t *testing.T, res resolveResult, err error, _ *boardSoA, _ *resolveContext) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !res.telemetry.radiantVision {
+					t.Fatalf("expected radiant vision active")
+				}
+			},
+		},
+		{
+			name:  "blinding tempo",
+			enemy: NewAbilitySet(AbilityBlinding),
+			expect: func(t *testing.T, res resolveResult, err error, _ *boardSoA, _ *resolveContext) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !res.telemetry.blindingSkipped {
+					t.Fatalf("expected blinding tempo")
+				}
+			},
+		},
+		{
+			name:  "light speed mover priority",
+			side:  NewAbilitySet(AbilityLightSpeed, AbilityBlazeRush),
+			enemy: NewAbilitySet(AbilityBlazeRush),
+			expect: func(t *testing.T, res resolveResult, err error, _ *boardSoA, ctx *resolveContext) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				log := res.telemetry.phaseLogs[int(phaseOffense)]
+				if log.count < 2 {
+					t.Fatalf("expected both sides in offense phase, got %d", log.count)
+				}
+				if log.owners[0] != ctx.board.colors[ctx.mover] {
+					t.Fatalf("expected mover to act first")
+				}
+				if res.telemetry.ck != King || res.telemetry.dk != Knight {
+					t.Fatalf("expected default CK/QK/DK ordering")
+				}
+			},
+		},
+		{
+			name:  "light speed enemy priority",
+			side:  NewAbilitySet(AbilityBlazeRush),
+			enemy: NewAbilitySet(AbilityLightSpeed, AbilityBlazeRush),
+			expect: func(t *testing.T, res resolveResult, err error, _ *boardSoA, ctx *resolveContext) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				log := res.telemetry.phaseLogs[int(phaseOffense)]
+				if log.count < 2 {
+					t.Fatalf("expected both sides in offense phase, got %d", log.count)
+				}
+				if log.owners[0] != ctx.board.colors[ctx.mover].Opposite() {
+					t.Fatalf("expected enemy to act first")
+				}
+				if res.telemetry.ck != Knight || res.telemetry.dk != King {
+					t.Fatalf("expected reversed CK/QK/DK ordering")
+				}
+			},
+		},
+		{
+			name: "anarchist sadist overrides",
+			side: NewAbilitySet(AbilityAnarchist, AbilitySadist),
+			expect: func(t *testing.T, res resolveResult, err error, _ *boardSoA, _ *resolveContext) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if res.telemetry.anarchist != AbilityScatterShot {
+					t.Fatalf("expected anarchist override")
+				}
+				if res.telemetry.sadist != AbilityScatterShot {
+					t.Fatalf("expected sadist override to follow anarchist")
+				}
+			},
+		},
+		{
+			name: "block path directive",
+			side: NewAbilitySet(AbilityBlockPath),
+			setup: func(_ *boardSoA, ctx *resolveContext) {
+				ctx.requestedDir = DirN
+			},
+			expect: func(t *testing.T, res resolveResult, err error, _ *boardSoA, ctx *resolveContext) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !res.setBlock || res.blockDir != ctx.requestedDir {
+					t.Fatalf("expected block direction honored")
+				}
+			},
+		},
+		{
+			name: "conflicting augmentors",
+			side: NewAbilitySet(AbilityMistShroud, AbilityRadiantVision),
+			expect: func(t *testing.T, _ resolveResult, err error, _ *boardSoA, _ *resolveContext) {
+				if err != ErrConflictingAugmentors {
+					t.Fatalf("expected conflicting augmentors error, got %v", err)
+				}
+			},
+		},
+		{
+			name: "invalid overload",
+			side: NewAbilitySet(AbilityOverload),
+			setup: func(b *boardSoA, _ *resolveContext) {
+				b.ability[0] = 0
+			},
+			expect: func(t *testing.T, _ resolveResult, err error, _ *boardSoA, _ *resolveContext) {
+				if err != ErrInvalidOverload {
+					t.Fatalf("expected invalid overload error, got %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			board := newEmptyBoard()
+			addPiece(&board, 0, 1, White, Knight, SquareD4)
+			board.turn = White
+			board.ability[0] = tc.side
+			doOver := [2]bool{}
+			ctx := resolveContext{
+				board:        &board,
+				mover:        0,
+				target:       SquareE4,
+				captureIdx:   -1,
+				sideMask:     tc.side,
+				enemyMask:    tc.enemy,
+				doOverUsed:   &doOver,
+				requestedDir: DirE,
+				sideElement:  ElementFire,
+				enemyElement: ElementWater,
+				seed:         0xACE0FACE,
+			}
+			if tc.setup != nil {
+				tc.setup(&board, &ctx)
+			}
+			resolver := newAbilityResolver()
+			res, err := resolver.resolve(ctx)
+			tc.expect(t, res, err, &board, &ctx)
+		})
+	}
+}

--- a/chessTest/internal/game/engine.go
+++ b/chessTest/internal/game/engine.go
@@ -109,6 +109,7 @@ func (e *Engine) Move(req MoveRequest) error {
 		e.board.removePiece(captureIdx)
 	}
 	e.board.movePiece(idx, req.To)
+	seed := uint64(e.board.ply)<<32 | uint64(e.board.ids[idx])<<16 | uint64(req.To)
 	ctx := resolveContext{
 		board:        &e.board,
 		mover:        idx,
@@ -118,8 +119,14 @@ func (e *Engine) Move(req MoveRequest) error {
 		enemyMask:    e.abilityMask[enemyColor.Index()],
 		doOverUsed:   &e.doOverUsed,
 		requestedDir: req.Dir,
+		sideElement:  e.elements[color.Index()],
+		enemyElement: e.elements[enemyColor.Index()],
+		seed:         seed,
 	}
-	res := e.resolver.resolve(ctx)
+	res, err := e.resolver.resolve(ctx)
+	if err != nil {
+		return err
+	}
 	if res.doOver {
 		last := e.history[len(e.history)-1]
 		e.board = last

--- a/chessTest/internal/game/errors.go
+++ b/chessTest/internal/game/errors.go
@@ -3,10 +3,16 @@ package game
 
 import "errors"
 
+type AbilityConfigError string
+
+func (e AbilityConfigError) Error() string { return string(e) }
+
 var (
-	ErrEngineLocked    = errors.New("engine locked")
-	ErrInvalidConfig   = errors.New("invalid configuration")
-	ErrInvalidMove     = errors.New("invalid move")
-	ErrDoOverActivated = errors.New("do-over activated")
-	ErrCaptureBlocked  = errors.New("capture blocked")
+	ErrEngineLocked                             = errors.New("engine locked")
+	ErrInvalidConfig                            = errors.New("invalid configuration")
+	ErrInvalidMove                              = errors.New("invalid move")
+	ErrDoOverActivated                          = errors.New("do-over activated")
+	ErrCaptureBlocked                           = errors.New("capture blocked")
+	ErrConflictingAugmentors AbilityConfigError = "conflicting augmentors"
+	ErrInvalidOverload       AbilityConfigError = "invalid overload loadout"
 )


### PR DESCRIPTION
## Summary
- add phased resolve pipeline with deterministic buffers, telemetry, and handlers covering new ability interactions and config validation
- extend the ability catalog and sentinel errors to support additional augmentors and invalid overload detection
- wire the engine to supply resolver context data and add comprehensive table-driven tests for key ability behaviors

## Testing
- (cd chessTest && go test ./...)

------
https://chatgpt.com/codex/tasks/task_e_68dc1ce65ca083238e713c7516b62358